### PR TITLE
Retrieve axis labels and views frames

### DIFF
--- a/Examples/Examples/HelloWorld.swift
+++ b/Examples/Examples/HelloWorld.swift
@@ -67,5 +67,37 @@ class HelloWorld: UIViewController {
         
         self.view.addSubview(chart.view)
         self.chart = chart
+        
+
+        // debug frames
+        
+        func debugView(frame: CGRect, labelText: String) -> UIView {
+            let v = UIView(frame: frame)
+            v.backgroundColor = UIColor.clearColor()
+            v.layer.borderWidth = 1
+            v.layer.borderColor = UIColor.redColor().CGColor
+            let l = UILabel(frame: CGRectMake(0, -10, frame.width + 20, 10))
+            l.font = UIFont.systemFontOfSize(8)
+            l.textColor = UIColor.redColor()
+            l.text = labelText
+            v.addSubview(l)
+            return v
+        }
+        
+        for (axisValue, frames) in yAxis.axisValuesWithFrames {
+            for frame in frames {
+                view.addSubview(debugView(CGRectMake(frame.origin.x, frame.origin.y + chartFrame.origin.y, frame.width, frame.height), labelText: axisValue.description))
+            }
+        }
+        
+        for (axisValue, frames) in xAxis.axisValuesWithFrames {
+            for frame in frames {
+                view.addSubview(debugView(CGRectMake(frame.origin.x, frame.origin.y + chartFrame.origin.y, frame.width, frame.height), labelText: axisValue.description))
+            }
+        }
+        
+        for (view, chartPointModel) in chartPointsLayer.viewsWithChartPoints {
+            self.view.addSubview(debugView(CGRectMake(view.frame.origin.x, view.frame.origin.y + chartFrame.origin.y, view.frame.width, view.frame.height), labelText: chartPointModel.chartPoint.description))
+        }
     }
 }

--- a/SwiftCharts/Axis/ChartAxisLayer.swift
+++ b/SwiftCharts/Axis/ChartAxisLayer.swift
@@ -26,6 +26,9 @@ public protocol ChartAxisLayer: ChartLayer {
     /// The screen locations that corresponds with the axis values
     var axisValuesScreenLocs: [CGFloat] {get}
 
+    /// The axis values with their respective frames relative to the chart's view
+    var axisValuesWithFrames: [(axisValue: ChartAxisValue, frames: [CGRect])] {get}
+    
     /// The screen locations that correspond with the visible axis values
     var visibleAxisValuesScreenLocs: [CGFloat] {get}
 

--- a/SwiftCharts/Axis/ChartAxisLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisLayerDefault.swift
@@ -56,6 +56,8 @@ public class ChartAxisSettings {
     }
 }
 
+typealias ChartAxisValueLabelDrawers = (axisValue: ChartAxisValue, drawers: [ChartLabelDrawer])
+
 /// A default implementation of ChartAxisLayer, which delegates drawing of the axis line and labels to the appropriate Drawers
 class ChartAxisLayerDefault: ChartAxisLayer {
     
@@ -67,7 +69,7 @@ class ChartAxisLayerDefault: ChartAxisLayer {
     
     // exposed for subclasses
     var lineDrawer: ChartLineDrawer?
-    var labelDrawers: [ChartLabelDrawer] = []
+    var labelDrawers: [ChartAxisValueLabelDrawers] = []
     var axisTitleLabelDrawers: [ChartLabelDrawer] = []
     
     var rect: CGRect {
@@ -76,6 +78,12 @@ class ChartAxisLayerDefault: ChartAxisLayer {
     
     var axisValuesScreenLocs: [CGFloat] {
         return self.axisValues.map{self.screenLocForScalar($0.scalar)}
+    }
+
+    var axisValuesWithFrames: [(axisValue: ChartAxisValue, frames: [CGRect])] {
+        return labelDrawers.map {(axisValue, drawers) in
+            (axisValue: axisValue, frames: drawers.map{$0.frame})
+        }
     }
     
     var visibleAxisValuesScreenLocs: [CGFloat] {
@@ -165,8 +173,10 @@ class ChartAxisLayerDefault: ChartAxisLayer {
             }
         }
         
-        for labelDrawer in self.labelDrawers {
-            labelDrawer.triggerDraw(context: context, chart: chart)
+        for (_, labelDrawers) in self.labelDrawers {
+            for labelDrawer in labelDrawers {
+                labelDrawer.triggerDraw(context: context, chart: chart)
+            }
         }
         for axisTitleLabelDrawer in self.axisTitleLabelDrawers {
             axisTitleLabelDrawer.triggerDraw(context: context, chart: chart)
@@ -186,7 +196,7 @@ class ChartAxisLayerDefault: ChartAxisLayer {
         fatalError("override")
     }
     
-    func generateLabelDrawers(offset offset: CGFloat) -> [ChartLabelDrawer] {
+    func generateLabelDrawers(offset offset: CGFloat) -> [ChartAxisValueLabelDrawers] {
         fatalError("override")
     }
 

--- a/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
@@ -88,15 +88,16 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
         return self.rowHeightsForRows(rows)
     }
     
-    override func generateLabelDrawers(offset offset: CGFloat) -> [ChartLabelDrawer] {
+    override func generateLabelDrawers(offset offset: CGFloat) -> [ChartAxisValueLabelDrawers] {
         
         let spacingLabelBetweenAxis = self.settings.labelsSpacing
         
         let rowHeights = self.rowHeights
         
-        // generate all the label drawers, in a flat list
+        // generate label drawers for each axis value and return them bundled with the respective axis value.
         return self.axisValues.flatMap {axisValue in
-            return Array(axisValue.labels.enumerate()).map {index, label in
+
+            let labelDrawers: [ChartLabelDrawer] = axisValue.labels.enumerate().map {index, label in
                 let rowY = self.calculateRowY(rowHeights: rowHeights, rowIndex: index, spacing: spacingLabelBetweenAxis)
                 
                 let x = self.screenLocForScalar(axisValue.scalar)
@@ -109,6 +110,7 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
                 labelDrawer.hidden = label.hidden
                 return labelDrawer
             }
+            return ChartAxisValueLabelDrawers(axisValue, labelDrawers)
         }
     }
     

--- a/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
@@ -20,7 +20,9 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
             return self.maxLabelWidth(self.axisValues)
         } else {
             return self.labelDrawers.reduce(0) {maxWidth, labelDrawer in
-                max(maxWidth, labelDrawer.size.width)
+                return max(maxWidth, labelDrawer.drawers.reduce(0) {maxWidth, drawer in
+                    max(maxWidth, drawer.size.width)
+                })
             }
         }
     }
@@ -61,14 +63,13 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
     }
     
     
-    override func generateLabelDrawers(offset offset: CGFloat) -> [ChartLabelDrawer] {
+    override func generateLabelDrawers(offset offset: CGFloat) -> [ChartAxisValueLabelDrawers] {
         
-        var drawers: [ChartLabelDrawer] = []
+        var drawers: [ChartAxisValueLabelDrawers] = []
         
         var lastDrawerWithRect: (drawer: ChartLabelDrawer, rect: CGRect)?
         
-        for i in 0..<axisValues.count {
-            let axisValue = axisValues[i]
+        for axisValue in axisValues {
             let scalar = axisValue.scalar
             let y = self.screenLocForScalar(scalar)
             if let axisLabel = axisValue.labels.first { // for now y axis supports only one label x value
@@ -76,10 +77,11 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
                 let labelY = y - (labelSize.height / 2)
                 let labelX = self.labelsX(offset: offset, labelWidth: labelSize.width, textAlignment: axisLabel.settings.textAlignment)
                 let labelDrawer = ChartLabelDrawer(text: axisLabel.text, screenLoc: CGPointMake(labelX, labelY), settings: axisLabel.settings)
+                let labelDrawers = ChartAxisValueLabelDrawers(axisValue, [labelDrawer])
                 labelDrawer.hidden = axisValue.hidden
 
                 let rect = CGRectMake(labelX, labelY, labelSize.width, labelSize.height)
-                drawers.append(labelDrawer)
+                drawers.append(labelDrawers)
                 
                 // move overlapping labels. This is for now a very simple algorithm and doesn't take into account possible overlappings resulting of moving the labels
                 if let (lastDrawer, lastRect) = lastDrawerWithRect {

--- a/SwiftCharts/Drawers/ChartLabelDrawer.swift
+++ b/SwiftCharts/Drawers/ChartLabelDrawer.swift
@@ -63,6 +63,10 @@ public class ChartLabelDrawer: ChartContextDrawer {
         return ChartUtils.textSize(self.text, font: self.settings.font)
     }
     
+    var frame: CGRect {
+        return CGRectMake(screenLoc.x, screenLoc.y, size.width, size.height)
+    }
+    
     init(text: String, screenLoc: CGPoint, settings: ChartLabelSettings) {
         self.text = text
         self.screenLoc = screenLoc

--- a/SwiftCharts/Layers/ChartPointsViewsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsViewsLayer.swift
@@ -14,7 +14,7 @@ public class ChartPointsViewsLayer<T: ChartPoint, U: UIView>: ChartPointsLayer<T
     public typealias ChartPointViewGenerator = (chartPointModel: ChartPointLayerModel<T>, layer: ChartPointsViewsLayer<T, U>, chart: Chart) -> U?
     public typealias ViewWithChartPoint = (view: U, chartPointModel: ChartPointLayerModel<T>)
     
-    private(set) var viewsWithChartPoints: [ViewWithChartPoint] = []
+    public private(set) var viewsWithChartPoints: [ViewWithChartPoint] = []
     
     private let delayBetweenItems: Float = 0
     


### PR DESCRIPTION
I store the label drawers for each axis value on generation and use this to return the frames. This avoids redundancy and ensures the retrieved frames are correct.

The axis value is associated with an array of label drawers/frames because axis values can have multiple labels. In case of y axis this currently will be always only 1 label/frame.

Also made the chart point layer's views getter public so it's also possible to retrieve these frames.

There's also a modified example to test this, which should be removed before merging.
