### PR TITLE
Separate axis from layer with related UI elements

### DIFF
--- a/Examples/Examples/AreasExample.swift
+++ b/Examples/Examples/AreasExample.swift
@@ -35,22 +35,22 @@ class AreasExample: UIViewController {
         chartSettings.labelsToAxisSpacingX = 20
         chartSettings.labelsToAxisSpacingY = 20
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         let c1 = UIColor(red: 0.1, green: 0.1, blue: 0.9, alpha: 0.4)
         let c2 = UIColor(red: 0.9, green: 0.1, blue: 0.1, alpha: 0.4)
         let c3 = UIColor(red: 0.1, green: 0.9, blue: 0.1, alpha: 0.4)
         
         
-        let chartPointsLayer1 = ChartPointsAreaLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints1, areaColor: c1, animDuration: 3, animDelay: 0, addContainerPoints: true)
-        let chartPointsLayer2 = ChartPointsAreaLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints2, areaColor: c2, animDuration: 3, animDelay: 0, addContainerPoints: true)
-        let chartPointsLayer3 = ChartPointsAreaLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints3, areaColor: c3, animDuration: 3, animDelay: 0, addContainerPoints: true)
+        let chartPointsLayer1 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints1, areaColor: c1, animDuration: 3, animDelay: 0, addContainerPoints: true)
+        let chartPointsLayer2 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints2, areaColor: c2, animDuration: 3, animDelay: 0, addContainerPoints: true)
+        let chartPointsLayer3 = ChartPointsAreaLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints3, areaColor: c3, animDuration: 3, animDelay: 0, addContainerPoints: true)
         
         let lineModel1 = ChartLineModel(chartPoints: chartPoints1, lineColor: UIColor.blackColor(), animDuration: 1, animDelay: 0)
         let lineModel2 = ChartLineModel(chartPoints: chartPoints2, lineColor: UIColor.blackColor(), animDuration: 1, animDelay: 0)
         let lineModel3 = ChartLineModel(chartPoints: chartPoints3, lineColor: UIColor.blackColor(), animDuration: 1, animDelay: 0)
         
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel1, lineModel2, lineModel3])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel1, lineModel2, lineModel3])
         
         var popups: [UIView] = []
         var selectedView: ChartPointTextCircleView?
@@ -107,20 +107,20 @@ class AreasExample: UIViewController {
         }
         
         let itemsDelay: Float = 0.08
-        let chartPointsCircleLayer1 = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints1, viewGenerator: circleViewGenerator, displayDelay: 0.9, delayBetweenItems: itemsDelay)
+        let chartPointsCircleLayer1 = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints1, viewGenerator: circleViewGenerator, displayDelay: 0.9, delayBetweenItems: itemsDelay)
         
-        let chartPointsCircleLayer2 = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints2, viewGenerator: circleViewGenerator, displayDelay: 1.8, delayBetweenItems: itemsDelay)
+        let chartPointsCircleLayer2 = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints2, viewGenerator: circleViewGenerator, displayDelay: 1.8, delayBetweenItems: itemsDelay)
         
-        let chartPointsCircleLayer3 = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints3, viewGenerator: circleViewGenerator, displayDelay: 2.7, delayBetweenItems: itemsDelay)
+        let chartPointsCircleLayer3 = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints3, viewGenerator: circleViewGenerator, displayDelay: 2.7, delayBetweenItems: itemsDelay)
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLayer1,
                 chartPointsLayer2,

--- a/Examples/Examples/BarsExample.swift
+++ b/Examples/Examples/BarsExample.swift
@@ -55,18 +55,18 @@ class BarsExample: UIViewController {
         let frame = ExamplesDefaults.chartFrame(self.view.bounds)
         let chartFrame = self.chart?.frame ?? CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height - sideSelectorHeight)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let chartPointsLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: barViewGenerator)
+        let chartPointsLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: barViewGenerator)
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         return Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLayer]
         )

--- a/Examples/Examples/BarsPlusMinusAndLinesExample.swift
+++ b/Examples/Examples/BarsPlusMinusAndLinesExample.swift
@@ -61,9 +61,9 @@ class BarsPlusMinusAndLinesExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let barsLayer = ChartBarsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, bars: bars, horizontal: false, barWidth: Env.iPad ? 40 : 25, animDuration: 0.5)
+        let barsLayer = ChartBarsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, bars: bars, horizontal: false, barWidth: Env.iPad ? 40 : 25, animDuration: 0.5)
         
         // labels layer
         // create chartpoints for the top and bottom of the bars, where we will show the labels
@@ -72,7 +72,7 @@ class BarsPlusMinusAndLinesExample: UIViewController {
         }
         let formatter = NSNumberFormatter()
         formatter.maximumFractionDigits = 2
-        let labelsLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: labelChartPoints, viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
+        let labelsLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: labelChartPoints, viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
             let label = HandlingLabel()
             let posOffset: CGFloat = 10
             
@@ -98,7 +98,7 @@ class BarsPlusMinusAndLinesExample: UIViewController {
         // line layer
         let lineChartPoints = lineData.enumerate().map {index, tuple in ChartPoint(x: ChartAxisValueDouble(index), y: ChartAxisValueDouble(tuple.val))}
         let lineModel = ChartLineModel(chartPoints: lineChartPoints, lineColor: UIColor.blackColor(), lineWidth: 2, animDuration: 0.5, animDelay: 1)
-        let lineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let lineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         
         let circleViewGenerator = {(chartPointModel: ChartPointLayerModel, layer: ChartPointsLayer, chart: Chart) -> UIView? in
             let color = UIColor(red: 0.7, green: 0.7, blue: 0.7, alpha: 1)
@@ -107,12 +107,12 @@ class BarsPlusMinusAndLinesExample: UIViewController {
             circleView.fillColor = color
             return circleView
         }
-        let lineCirclesLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: lineChartPoints, viewGenerator: circleViewGenerator, displayDelay: 1.5, delayBetweenItems: 0.05)
+        let lineCirclesLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: lineChartPoints, viewGenerator: circleViewGenerator, displayDelay: 1.5, delayBetweenItems: 0.05)
         
         
         // show a gap between positive and negative bar
         let dummyZeroYChartPoint = ChartPoint(x: ChartAxisValueDouble(0), y: ChartAxisValueDouble(0))
-        let yZeroGapLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: [dummyZeroYChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
+        let yZeroGapLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: [dummyZeroYChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
             let height: CGFloat = 2
             let v = UIView(frame: CGRectMake(innerFrame.origin.x + 2, chartPointModel.screenLoc.y - height / 2, innerFrame.origin.x + innerFrame.size.height, height))
             v.backgroundColor = UIColor.whiteColor()
@@ -122,8 +122,8 @@ class BarsPlusMinusAndLinesExample: UIViewController {
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 barsLayer,
                 labelsLayer,
                 yZeroGapLayer,

--- a/Examples/Examples/BarsPlusMinusWithGradientExample.swift
+++ b/Examples/Examples/BarsPlusMinusWithGradientExample.swift
@@ -82,16 +82,16 @@ class BarsPlusMinusWithGradientExample: UIViewController {
             
             dispatch_async(dispatch_get_main_queue()) {
                 
-                let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+                let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
                 
-                let barsLayer = ChartBarsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, bars: bars, horizontal: true, barWidth: Env.iPad ? 40 : 16, animDuration: 0.5)
+                let barsLayer = ChartBarsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, bars: bars, horizontal: true, barWidth: Env.iPad ? 40 : 16, animDuration: 0.5)
                 
                 let settings = ChartGuideLinesLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-                let guidelinesLayer = ChartGuideLinesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, axis: .X, settings: settings)
+                let guidelinesLayer = ChartGuideLinesLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, axis: .X, settings: settings)
                 
                 // create x zero guideline as view to be in front of the bars
                 let dummyZeroXChartPoint = ChartPoint(x: ChartAxisValueDouble(0), y: ChartAxisValueDouble(0))
-                let xZeroGuidelineLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: [dummyZeroXChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
+                let xZeroGuidelineLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: [dummyZeroXChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
                     let width: CGFloat = 2
                     let v = UIView(frame: CGRectMake(chartPointModel.screenLoc.x - width / 2, innerFrame.origin.y, width, innerFrame.size.height))
                     v.backgroundColor = UIColor(red: 1, green: 69 / 255, blue: 0, alpha: 1)
@@ -101,8 +101,8 @@ class BarsPlusMinusWithGradientExample: UIViewController {
                 let chart = Chart(
                     frame: chartFrame,
                     layers: [
-                        xAxis,
-                        yAxis,
+                        xAxisLayer,
+                        yAxisLayer,
                         guidelinesLayer,
                         barsLayer,
                         xZeroGuidelineLayer

--- a/Examples/Examples/BubbleExample.swift
+++ b/Examples/Examples/BubbleExample.swift
@@ -69,21 +69,21 @@ class BubbleExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
 
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let bubbleLayer = self.bubblesLayer(xAxis: xAxis, yAxis: yAxis, chartInnerFrame: innerFrame, chartPoints: chartPoints)
+        let bubbleLayer = self.bubblesLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, chartInnerFrame: innerFrame, chartPoints: chartPoints)
         
         let guidelinesLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: guidelinesLayerSettings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: guidelinesLayerSettings)
 
         let guidelinesHighlightLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.redColor(), linesWidth: 1, dotWidth: 4, dotSpacing: 4)
-        let guidelinesHighlightLayer = ChartGuideLinesForValuesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: guidelinesHighlightLayerSettings, axisValuesX: [ChartAxisValueDouble(0)], axisValuesY: [ChartAxisValueDouble(0)])
+        let guidelinesHighlightLayer = ChartGuideLinesForValuesDottedLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, settings: guidelinesHighlightLayerSettings, axisValuesX: [ChartAxisValueDouble(0)], axisValuesY: [ChartAxisValueDouble(0)])
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 guidelinesHighlightLayer,
                 bubbleLayer
@@ -96,7 +96,7 @@ class BubbleExample: UIViewController {
     
     // We can use a view based layer for easy animation (or interactivity), in which case we use the default chart points layer with a generator to create bubble views.
     // On the other side, if we don't need animation or want a better performance, we use ChartPointsBubbleLayer, which instead of creating views, renders directly to the chart's context.
-    private func bubblesLayer(xAxis xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, chartPoints: [ChartPointBubble]) -> ChartLayer {
+    private func bubblesLayer(xAxisLayer xAxisLayer: ChartAxisLayer, yAxisLayer: ChartAxisLayer, chartInnerFrame: CGRect, chartPoints: [ChartPointBubble]) -> ChartLayer {
         
         let maxBubbleDiameter: Double = 30, minBubbleDiameter: Double = 2
         
@@ -108,7 +108,7 @@ class BubbleExample: UIViewController {
             
             let diameterFactor = (maxBubbleDiameter - minBubbleDiameter) / (maxDiameterScalar - minDiameterScalar)
 
-            return ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
+            return ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: chartInnerFrame, chartPoints: chartPoints, viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
 
                 let diameter = CGFloat(chartPointModel.chartPoint.diameterScalar * diameterFactor)
                 
@@ -124,7 +124,7 @@ class BubbleExample: UIViewController {
             })
             
         } else {
-            return ChartPointsBubbleLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints)
+            return ChartPointsBubbleLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: chartInnerFrame, chartPoints: chartPoints)
         }
     }
 

--- a/Examples/Examples/CandleStickExample.swift
+++ b/Examples/Examples/CandleStickExample.swift
@@ -92,21 +92,21 @@ class CandleStickExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceRightBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let chartPointsLineLayer = ChartCandleStickLayer<ChartPointCandleStick>(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, itemWidth: Env.iPad ? 10 : 5, strokeWidth: Env.iPad ? 1 : 0.6)
+        let chartPointsLineLayer = ChartCandleStickLayer<ChartPointCandleStick>(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, itemWidth: Env.iPad ? 10 : 5, strokeWidth: Env.iPad ? 1 : 0.6)
         
         let settings = ChartGuideLinesLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings, onlyVisibleX: true)
+        let guidelinesLayer = ChartGuideLinesLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings, onlyVisibleX: true)
         
         let dividersSettings =  ChartDividersLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth, start: Env.iPad ? 7 : 3, end: 0, onlyVisibleValues: true)
-        let dividersLayer = ChartDividersLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: dividersSettings)
+        let dividersLayer = ChartDividersLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: dividersSettings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 dividersLayer,
                 chartPointsLineLayer

--- a/Examples/Examples/CandleStickInteractiveExample.swift
+++ b/Examples/Examples/CandleStickInteractiveExample.swift
@@ -95,7 +95,7 @@ class CandleStickInteractiveExample: UIViewController {
         let infoViewHeight: CGFloat = 50
         let chartFrame = CGRectMake(defaultChartFrame.origin.x, defaultChartFrame.origin.y + infoViewHeight, defaultChartFrame.width, defaultChartFrame.height - infoViewHeight)
         let coordsSpace = ChartCoordsSpaceRightBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         let viewGenerator = {(chartPointModel: ChartPointLayerModel<ChartPointCandleStick>, layer: ChartPointsViewsLayer<ChartPointCandleStick, ChartCandleStickView>, chart: Chart) -> ChartCandleStickView? in
             let (chartPoint, screenLoc) = (chartPointModel.chartPoint, chartPointModel.screenLoc)
@@ -112,13 +112,13 @@ class CandleStickInteractiveExample: UIViewController {
             v.userInteractionEnabled = false
             return v
         }
-        let candleStickLayer = ChartPointsCandleStickViewsLayer<ChartPointCandleStick, ChartCandleStickView>(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: viewGenerator)
+        let candleStickLayer = ChartPointsCandleStickViewsLayer<ChartPointCandleStick, ChartCandleStickView>(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: viewGenerator)
         
         
         let infoView = InfoWithIntroView(frame: CGRectMake(10, 70, self.view.frame.size.width, infoViewHeight))
         self.view.addSubview(infoView)
         
-        let trackerLayer = ChartPointsTrackerLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, locChangedFunc: {[weak candleStickLayer, weak infoView] screenLoc in
+        let trackerLayer = ChartPointsTrackerLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, locChangedFunc: {[weak candleStickLayer, weak infoView] screenLoc in
             candleStickLayer?.highlightChartpointView(screenLoc: screenLoc)
             if let chartPoint = candleStickLayer?.chartPointsForScreenLocX(screenLoc.x).first {
                 infoView?.showChartPoint(chartPoint)
@@ -129,16 +129,16 @@ class CandleStickInteractiveExample: UIViewController {
         
         
         let settings = ChartGuideLinesLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings, onlyVisibleX: true)
+        let guidelinesLayer = ChartGuideLinesLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings, onlyVisibleX: true)
         
         let dividersSettings =  ChartDividersLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth, start: Env.iPad ? 7 : 3, end: 0, onlyVisibleValues: true)
-        let dividersLayer = ChartDividersLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: dividersSettings)
+        let dividersLayer = ChartDividersLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: dividersSettings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 dividersLayer,
                 candleStickLayer,

--- a/Examples/Examples/CoordsExample.swift
+++ b/Examples/Examples/CoordsExample.swift
@@ -32,7 +32,7 @@ class CoordsExample: UIViewController {
         chartSettings.labelsToAxisSpacingX = 15
         chartSettings.labelsToAxisSpacingY = 15
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         let showCoordsTextViewsGenerator = {(chartPointModel: ChartPointLayerModel, layer: ChartPointsLayer, chart: Chart) -> UIView? in
             let (chartPoint, screenLoc) = (chartPointModel.chartPoint, chartPointModel.screenLoc)
@@ -55,8 +55,8 @@ class CoordsExample: UIViewController {
             return view
         }
         
-        let showCoordsLinesLayer = ChartShowCoordsLinesLayer<ChartPoint>(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints)
-        let showCoordsTextLayer = ChartPointsSingleViewLayer<ChartPoint, UIView>(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: showCoordsTextViewsGenerator)
+        let showCoordsLinesLayer = ChartShowCoordsLinesLayer<ChartPoint>(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints)
+        let showCoordsTextLayer = ChartPointsSingleViewLayer<ChartPoint, UIView>(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: showCoordsTextViewsGenerator)
         
         let touchViewsGenerator = {(chartPointModel: ChartPointLayerModel, layer: ChartPointsLayer, chart: Chart) -> UIView? in
             let (chartPoint, screenLoc) = (chartPointModel.chartPoint, chartPointModel.screenLoc)
@@ -70,10 +70,10 @@ class CoordsExample: UIViewController {
             return view
         }
         
-        let touchLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: touchViewsGenerator)
+        let touchLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: touchViewsGenerator)
         
         let lineModel = ChartLineModel(chartPoints: chartPoints, lineColor: UIColor(red: 0.4, green: 0.4, blue: 1, alpha: 0.2), lineWidth: 3, animDuration: 0.7, animDelay: 0)
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         
         let circleViewGenerator = {(chartPointModel: ChartPointLayerModel, layer: ChartPointsLayer, chart: Chart) -> UIView? in
             let circleView = ChartPointEllipseView(center: chartPointModel.screenLoc, diameter: 24)
@@ -83,17 +83,17 @@ class CoordsExample: UIViewController {
             circleView.borderColor = UIColor.blueColor()
             return circleView
         }
-        let chartPointsCircleLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: circleViewGenerator, displayDelay: 0, delayBetweenItems: 0.05)
+        let chartPointsCircleLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: circleViewGenerator, displayDelay: 0, delayBetweenItems: 0.05)
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 showCoordsLinesLayer,
                 chartPointsLineLayer,

--- a/Examples/Examples/CubicLinesExample.swift
+++ b/Examples/Examples/CubicLinesExample.swift
@@ -27,19 +27,19 @@ class CubicLinesExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         let lineModel = ChartLineModel(chartPoints: chartPoints, lineColor: UIColor.purpleColor(), lineWidth: 2, animDuration: 1, animDelay: 0)
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel], pathGenerator: CubicLinePathGenerator(tension1: 0.3, tension2: 0.3))
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel], pathGenerator: CubicLinePathGenerator(tension1: 0.3, tension2: 0.3))
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLineLayer
             ]

--- a/Examples/Examples/CustomUnitsExample.swift
+++ b/Examples/Examples/CustomUnitsExample.swift
@@ -82,19 +82,19 @@ class CustomUnitsExample: UIViewController {
         let chartSettings = ExamplesDefaults.chartSettings
         chartSettings.trailing = 80
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         let lineModel = ChartLineModel(chartPoints: chartPoints, lineColor: UIColor.redColor(), animDuration: 1, animDelay: 0)
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                coordsSpace.xAxis,
-                coordsSpace.yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLineLayer]
         )

--- a/Examples/Examples/EqualSpacingExample.swift
+++ b/Examples/Examples/EqualSpacingExample.swift
@@ -34,19 +34,19 @@ class EqualSpacingExample: UIViewController {
         let chartSettings = ExamplesDefaults.chartSettings
         chartSettings.trailing = 40
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
     
         let lineModel = ChartLineModel(chartPoints: chartPoints, lineColor: UIColor.redColor(), animDuration: 1, animDelay: 0)
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLineLayer
             ]

--- a/Examples/Examples/GroupedAndStackedBarsExample.swift
+++ b/Examples/Examples/GroupedAndStackedBarsExample.swift
@@ -91,15 +91,15 @@ class GroupedAndStackedBarsExample: UIViewController {
         let frame = ExamplesDefaults.chartFrame(self.view.bounds)
         let chartFrame = self.chart?.frame ?? CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height - self.dirSelectorHeight)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let groupsLayer = ChartGroupedStackedBarsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, groups: groups, horizontal: horizontal, barSpacing: 2, groupSpacing: 30, animDuration: 0.5)
+        let groupsLayer = ChartGroupedStackedBarsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, groups: groups, horizontal: horizontal, barSpacing: 2, groupSpacing: 30, animDuration: 0.5)
         
         let settings = ChartGuideLinesLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, axis: horizontal ? .X : .Y, settings: settings)
+        let guidelinesLayer = ChartGuideLinesLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, axis: horizontal ? .X : .Y, settings: settings)
         
         let dummyZeroChartPoint = ChartPoint(x: ChartAxisValueDouble(0), y: ChartAxisValueDouble(0))
-        let zeroGuidelineLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: [dummyZeroChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
+        let zeroGuidelineLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: [dummyZeroChartPoint], viewGenerator: {(chartPointModel, layer, chart) -> UIView? in
             let width: CGFloat = 2
             
             let viewFrame: CGRect = {
@@ -118,8 +118,8 @@ class GroupedAndStackedBarsExample: UIViewController {
         return Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 groupsLayer,
                 zeroGuidelineLayer

--- a/Examples/Examples/GroupedBarsExample.swift
+++ b/Examples/Examples/GroupedBarsExample.swift
@@ -64,18 +64,18 @@ class GroupedBarsExample: UIViewController {
         let frame = ExamplesDefaults.chartFrame(self.view.bounds)
         let chartFrame = self.chart?.frame ?? CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height - self.dirSelectorHeight)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let groupsLayer = ChartGroupedPlainBarsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, groups: groups, horizontal: horizontal, barSpacing: 2, groupSpacing: 25, animDuration: 0.5)
+        let groupsLayer = ChartGroupedPlainBarsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, groups: groups, horizontal: horizontal, barSpacing: 2, groupSpacing: 25, animDuration: 0.5)
         
         let settings = ChartGuideLinesLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, axis: horizontal ? .X : .Y, settings: settings)
+        let guidelinesLayer = ChartGuideLinesLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, axis: horizontal ? .X : .Y, settings: settings)
         
         return Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 groupsLayer
             ]

--- a/Examples/Examples/HelloWorld.swift
+++ b/Examples/Examples/HelloWorld.swift
@@ -33,11 +33,11 @@ class HelloWorld: UIViewController {
         
         // generate axes layers and calculate chart inner frame, based on the axis models
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         // create layer with guidelines
         let guidelinesLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: guidelinesLayerSettings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: guidelinesLayerSettings)
         
         // view generator - this is a function that creates a view for each chartpoint
         let viewGenerator = {(chartPointModel: ChartPointLayerModel, layer: ChartPointsViewsLayer, chart: Chart) -> UIView? in
@@ -52,14 +52,14 @@ class HelloWorld: UIViewController {
         }
         
         // create layer that uses viewGenerator to display chartpoints
-        let chartPointsLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: viewGenerator)
+        let chartPointsLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: viewGenerator)
         
         // create chart instance with frame and layers
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                coordsSpace.xAxis,
-                coordsSpace.yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLayer
             ]

--- a/Examples/Examples/MultipleAxesExample.swift
+++ b/Examples/Examples/MultipleAxesExample.swift
@@ -116,10 +116,10 @@ class MultipleAxesExample: UIViewController {
                 let chartInnerFrame = coordsSpace.chartInnerFrame
                 
                 // create axes
-                let yLowAxes = coordsSpace.yLowAxes
-                let yHighAxes = coordsSpace.yHighAxes
-                let xLowAxes = coordsSpace.xLowAxes
-                let xHighAxes = coordsSpace.xHighAxes
+                let yLowAxes = coordsSpace.yLowAxesLayers
+                let yHighAxes = coordsSpace.yHighAxesLayers
+                let xLowAxes = coordsSpace.xLowAxesLayers
+                let xHighAxes = coordsSpace.xHighAxesLayers
                 
                 // create layers with references to axes
                 let lineModel0 = ChartLineModel(chartPoints: chartPoints0, lineColor: bgColors[0], animDuration: 1, animDelay: 0)
@@ -127,10 +127,10 @@ class MultipleAxesExample: UIViewController {
                 let lineModel2 = ChartLineModel(chartPoints: chartPoints2, lineColor: bgColors[2], animDuration: 1, animDelay: 0)
                 let lineModel3 = ChartLineModel(chartPoints: chartPoints3, lineColor: bgColors[3], animDuration: 1, animDelay: 0)
                 
-                let chartPointsLineLayer0 = ChartPointsLineLayer<ChartPoint>(xAxis: xLowAxes[0], yAxis: yLowAxes[1], innerFrame: chartInnerFrame, lineModels: [lineModel0])
-                let chartPointsLineLayer1 = ChartPointsLineLayer<ChartPoint>(xAxis: xLowAxes[1], yAxis: yLowAxes[0], innerFrame: chartInnerFrame, lineModels: [lineModel1])
-                let chartPointsLineLayer3 = ChartPointsLineLayer<ChartPoint>(xAxis: xHighAxes[1], yAxis: yHighAxes[0], innerFrame: chartInnerFrame, lineModels: [lineModel2])
-                let chartPointsLineLayer4 = ChartPointsLineLayer<ChartPoint>(xAxis: xHighAxes[0], yAxis: yHighAxes[1], innerFrame: chartInnerFrame, lineModels: [lineModel3])
+                let chartPointsLineLayer0 = ChartPointsLineLayer<ChartPoint>(xAxis: xLowAxes[0].axis, yAxis: yLowAxes[1].axis, innerFrame: chartInnerFrame, lineModels: [lineModel0])
+                let chartPointsLineLayer1 = ChartPointsLineLayer<ChartPoint>(xAxis: xLowAxes[1].axis, yAxis: yLowAxes[0].axis, innerFrame: chartInnerFrame, lineModels: [lineModel1])
+                let chartPointsLineLayer3 = ChartPointsLineLayer<ChartPoint>(xAxis: xHighAxes[1].axis, yAxis: yHighAxes[0].axis, innerFrame: chartInnerFrame, lineModels: [lineModel2])
+                let chartPointsLineLayer4 = ChartPointsLineLayer<ChartPoint>(xAxis: xHighAxes[0].axis, yAxis: yHighAxes[1].axis, innerFrame: chartInnerFrame, lineModels: [lineModel3])
                 
                 let lineLayers = [chartPointsLineLayer0, chartPointsLineLayer1, chartPointsLineLayer3, chartPointsLineLayer4]
                 

--- a/Examples/Examples/MultipleAxesInteractiveExample.swift
+++ b/Examples/Examples/MultipleAxesInteractiveExample.swift
@@ -26,10 +26,10 @@ class MultipleAxesInteractiveExample: UIViewController {
     private var viewFrame: CGRect!
     private var chartInnerFrame: CGRect!
     
-    private var yLowAxes: [ChartAxisLayer]!
-    private var yHighAxes: [ChartAxisLayer]!
-    private var xLowAxes: [ChartAxisLayer]!
-    private var xHighAxes: [ChartAxisLayer]!
+    private var yLowAxesLayers: [ChartAxisLayer]!
+    private var yHighAxesLayers: [ChartAxisLayer]!
+    private var xLowAxesLayers: [ChartAxisLayer]!
+    private var xHighAxesLayers: [ChartAxisLayer]!
     
     private var guideLinesLayer0: ChartLayer!
     private var guideLinesLayer1: ChartLayer!
@@ -155,20 +155,20 @@ class MultipleAxesInteractiveExample: UIViewController {
                 self.chartInnerFrame = coordsSpace.chartInnerFrame
                 
                 // create axes
-                self.yLowAxes = coordsSpace.yLowAxes
-                self.yHighAxes = coordsSpace.yHighAxes
-                self.xLowAxes = coordsSpace.xLowAxes
-                self.xHighAxes = coordsSpace.xHighAxes
+                self.yLowAxesLayers = coordsSpace.yLowAxesLayers
+                self.yHighAxesLayers = coordsSpace.yHighAxesLayers
+                self.xLowAxesLayers = coordsSpace.xLowAxesLayers
+                self.xHighAxesLayers = coordsSpace.xHighAxesLayers
                 
                 // create layers with references to axes
                 let guideLinesLayer0Settings = ChartGuideLinesDottedLayerSettings(linesColor: self.bgColors[0], linesWidth: ExamplesDefaults.guidelinesWidth)
-                self.guideLinesLayer0 = ChartGuideLinesDottedLayer(xAxis: self.xLowAxes[0], yAxis: self.yLowAxes[1], innerFrame: self.chartInnerFrame, settings: guideLinesLayer0Settings)
+                self.guideLinesLayer0 = ChartGuideLinesDottedLayer(xAxisLayer: self.xLowAxesLayers[0], yAxisLayer: self.yLowAxesLayers[1], innerFrame: self.chartInnerFrame, settings: guideLinesLayer0Settings)
                 let guideLinesLayer1Settings = ChartGuideLinesDottedLayerSettings(linesColor: self.bgColors[1], linesWidth: ExamplesDefaults.guidelinesWidth)
-                self.guideLinesLayer1 = ChartGuideLinesDottedLayer(xAxis: self.xLowAxes[1], yAxis: self.yLowAxes[0], innerFrame: self.chartInnerFrame, settings: guideLinesLayer1Settings)
+                self.guideLinesLayer1 = ChartGuideLinesDottedLayer(xAxisLayer: self.xLowAxesLayers[1], yAxisLayer: self.yLowAxesLayers[0], innerFrame: self.chartInnerFrame, settings: guideLinesLayer1Settings)
                 let guideLinesLayer3Settings = ChartGuideLinesDottedLayerSettings(linesColor: self.bgColors[2], linesWidth: ExamplesDefaults.guidelinesWidth)
-                self.guideLinesLayer2 = ChartGuideLinesDottedLayer(xAxis: self.xHighAxes[1], yAxis: self.yHighAxes[0], innerFrame: self.chartInnerFrame, settings: guideLinesLayer3Settings)
+                self.guideLinesLayer2 = ChartGuideLinesDottedLayer(xAxisLayer: self.xHighAxesLayers[1], yAxisLayer: self.yHighAxesLayers[0], innerFrame: self.chartInnerFrame, settings: guideLinesLayer3Settings)
                 let guideLinesLayer4Settings = ChartGuideLinesDottedLayerSettings(linesColor: self.bgColors[3], linesWidth: ExamplesDefaults.guidelinesWidth)
-                self.guideLinesLayer3 = ChartGuideLinesDottedLayer(xAxis: self.xHighAxes[0], yAxis: self.yHighAxes[1], innerFrame: self.chartInnerFrame, settings: guideLinesLayer4Settings)
+                self.guideLinesLayer3 = ChartGuideLinesDottedLayer(xAxisLayer: self.xHighAxesLayers[0], yAxisLayer: self.yHighAxesLayers[1], innerFrame: self.chartInnerFrame, settings: guideLinesLayer4Settings)
                 
                 self.showChart(lineAnimDuration: 1)
             }
@@ -185,10 +185,10 @@ class MultipleAxesInteractiveExample: UIViewController {
         let lineModel2 = ChartLineModel(chartPoints: chartPoints2, lineColor: bgColors[2], animDuration: animDuration, animDelay: 0)
         let lineModel3 = ChartLineModel(chartPoints: chartPoints3, lineColor: bgColors[3], animDuration: animDuration, animDelay: 0)
         
-        let chartPointsLineLayer0 = ChartPointsLineLayer<ChartPoint>(xAxis: xLowAxes[0], yAxis: yLowAxes[1], innerFrame: chartInnerFrame, lineModels: [lineModel0])
-        let chartPointsLineLayer1 = ChartPointsLineLayer<ChartPoint>(xAxis: xLowAxes[1], yAxis: yLowAxes[0], innerFrame: chartInnerFrame, lineModels: [lineModel1])
-        let chartPointsLineLayer2 = ChartPointsLineLayer<ChartPoint>(xAxis: xHighAxes[1], yAxis: yHighAxes[0], innerFrame: chartInnerFrame, lineModels: [lineModel2])
-        let chartPointsLineLayer3 = ChartPointsLineLayer<ChartPoint>(xAxis: xHighAxes[0], yAxis: yHighAxes[1], innerFrame: chartInnerFrame, lineModels: [lineModel3])
+        let chartPointsLineLayer0 = ChartPointsLineLayer<ChartPoint>(xAxis: xLowAxesLayers[0].axis, yAxis: yLowAxesLayers[1].axis, innerFrame: chartInnerFrame, lineModels: [lineModel0])
+        let chartPointsLineLayer1 = ChartPointsLineLayer<ChartPoint>(xAxis: xLowAxesLayers[1].axis, yAxis: yLowAxesLayers[0].axis, innerFrame: chartInnerFrame, lineModels: [lineModel1])
+        let chartPointsLineLayer2 = ChartPointsLineLayer<ChartPoint>(xAxis: xHighAxesLayers[1].axis, yAxis: yHighAxesLayers[0].axis, innerFrame: chartInnerFrame, lineModels: [lineModel2])
+        let chartPointsLineLayer3 = ChartPointsLineLayer<ChartPoint>(xAxis: xHighAxesLayers[0].axis, yAxis: yHighAxesLayers[1].axis, innerFrame: chartInnerFrame, lineModels: [lineModel3])
         
         return [chartPointsLineLayer0, chartPointsLineLayer1, chartPointsLineLayer2, chartPointsLineLayer3]
     }
@@ -206,10 +206,10 @@ class MultipleAxesInteractiveExample: UIViewController {
         }
         
         let layers: [[ChartLayer]] = [
-            [yLowAxes[1], xLowAxes[0], lineLayers[0]] + maybeGuides(guideLinesLayer0),
-            [yLowAxes[0], xLowAxes[1], lineLayers[1]] + maybeGuides(guideLinesLayer1),
-            [yHighAxes[0], xHighAxes[1], lineLayers[2]] + maybeGuides(guideLinesLayer2),
-            [yHighAxes[1], xHighAxes[0], lineLayers[3]] + maybeGuides(guideLinesLayer3)
+            [yLowAxesLayers[1], xLowAxesLayers[0], lineLayers[0]] + maybeGuides(guideLinesLayer0),
+            [yLowAxesLayers[0], xLowAxesLayers[1], lineLayers[1]] + maybeGuides(guideLinesLayer1),
+            [yHighAxesLayers[0], xHighAxesLayers[1], lineLayers[2]] + maybeGuides(guideLinesLayer2),
+            [yHighAxesLayers[1], xHighAxesLayers[0], lineLayers[3]] + maybeGuides(guideLinesLayer3)
         ]
         
         return selectedLayersFlags.enumerate().reduce(Array<ChartLayer>()) {selectedLayers, inTuple in

--- a/Examples/Examples/MultipleLabelsExample.swift
+++ b/Examples/Examples/MultipleLabelsExample.swift
@@ -34,19 +34,19 @@ class MultipleLabelsExample: UIViewController {
         let chartSettings = ExamplesDefaults.chartSettings
         chartSettings.trailing = 20
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
     
         let lineModel = ChartLineModel(chartPoints: chartPoints, lineColor: UIColor.redColor(), lineWidth: 1, animDuration: 1, animDelay: 0)
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLineLayer
             ]

--- a/Examples/Examples/NotNumericExample.swift
+++ b/Examples/Examples/NotNumericExample.swift
@@ -51,7 +51,7 @@ class NotNumericExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         let minBarSpacing: CGFloat = ExamplesDefaults.minBarSpacing + 16
 
@@ -64,19 +64,19 @@ class NotNumericExample: UIViewController {
             return ChartPointViewBar(p1: p1, p2: p2, width: barWidth, bgColor: UIColor.blueColor().colorWithAlphaComponent(0.6))
         }
         
-        let chartPointsLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: generator)
+        let chartPointsLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: generator)
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let dividersSettings =  ChartDividersLayerSettings(linesColor: UIColor.blackColor(), linesWidth: Env.iPad ? 1 : 0.2, start: Env.iPad ? 7 : 3, end: 0, onlyVisibleValues: true)
-        let dividersLayer = ChartDividersLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: dividersSettings)
+        let dividersLayer = ChartDividersLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: dividersSettings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 dividersLayer,
                 chartPointsLayer

--- a/Examples/Examples/NotificationsExample.swift
+++ b/Examples/Examples/NotificationsExample.swift
@@ -77,20 +77,20 @@ class NotificationsExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
 
-        let chartPointsNotificationsLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: notificationGenerator, displayDelay: 1)
+        let chartPointsNotificationsLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: notificationGenerator, displayDelay: 1)
         
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLineLayer,
                 chartPointsNotificationsLayer]

--- a/Examples/Examples/ScatterExample.swift
+++ b/Examples/Examples/ScatterExample.swift
@@ -45,18 +45,18 @@ class ScatterExample: UIViewController {
         
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
 
-        let scatterLayers = self.toLayers(models, layerSpecifications: layerSpecifications, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: innerFrame)
+        let scatterLayers = self.toLayers(models, layerSpecifications: layerSpecifications, xAxis: xAxisLayer, yAxis: yAxisLayer, chartInnerFrame: innerFrame)
         
         let guidelinesLayerSettings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: guidelinesLayerSettings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: guidelinesLayerSettings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer
             ] + scatterLayers
         )
@@ -86,13 +86,13 @@ class ScatterExample: UIViewController {
             let layerSpecification = layerSpecifications[type]!
             switch layerSpecification.shape {
                 case .Triangle:
-                    return ChartPointsScatterTrianglesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
+                    return ChartPointsScatterTrianglesLayer(xAxis: xAxis.axis, yAxis: yAxis.axis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
                 case .Square:
-                    return ChartPointsScatterSquaresLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
+                    return ChartPointsScatterSquaresLayer(xAxis: xAxis.axis, yAxis: yAxis.axis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
                 case .Circle:
-                    return ChartPointsScatterCirclesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
+                    return ChartPointsScatterCirclesLayer(xAxis: xAxis.axis, yAxis: yAxis.axis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
                 case .Cross:
-                    return ChartPointsScatterCrossesLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
+                    return ChartPointsScatterCrossesLayer(xAxis: xAxis.axis, yAxis: yAxis.axis, innerFrame: chartInnerFrame, chartPoints: chartPoints, itemSize: size, itemFillColor: layerSpecification.color)
             }
         }
         

--- a/Examples/Examples/ScrollExample.swift
+++ b/Examples/Examples/ScrollExample.swift
@@ -68,14 +68,14 @@ class ScrollExample: UIViewController {
             let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
             
             dispatch_async(dispatch_get_main_queue()) {
-                let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+                let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
 
                 let lineModel0 = ChartLineModel(chartPoints: chartPoints0, lineColor: UIColor.redColor(), animDuration: 1, animDelay: 0)
                 let lineModel1 = ChartLineModel(chartPoints: chartPoints1, lineColor: UIColor.blueColor(), animDuration: 1, animDelay: 0)
-                let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel0, lineModel1])
+                let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel0, lineModel1])
                 
                 let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-                let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+                let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
                 
                 let scrollView = UIScrollView(frame: scrollViewFrame)
                 scrollView.contentSize = CGSizeMake(chartFrame.size.width, scrollViewFrame.size.height)
@@ -84,8 +84,8 @@ class ScrollExample: UIViewController {
                 let chart = Chart(
                     frame: chartFrame,
                     layers: [
-                        xAxis,
-                        yAxis,
+                        xAxisLayer,
+                        yAxisLayer,
                         guidelinesLayer,
                         chartPointsLineLayer
                     ]

--- a/Examples/Examples/StackedBarsExample.swift
+++ b/Examples/Examples/StackedBarsExample.swift
@@ -63,18 +63,18 @@ class StackedBarsExample: UIViewController {
         let frame = ExamplesDefaults.chartFrame(self.view.bounds)
         let chartFrame = self.chart?.frame ?? CGRectMake(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height - sideSelectorHeight)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let chartStackedBarsLayer = ChartStackedBarsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, barModels: barModels, horizontal: horizontal, barWidth: 40, animDuration: 0.5)
+        let chartStackedBarsLayer = ChartStackedBarsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, barModels: barModels, horizontal: horizontal, barWidth: 40, animDuration: 0.5)
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         return Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartStackedBarsLayer
             ]

--- a/Examples/Examples/TargetExample.swift
+++ b/Examples/Examples/TargetExample.swift
@@ -28,7 +28,7 @@ class TargetExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
        
         let lineModel = ChartLineModel(chartPoints: chartPoints, lineColor: UIColor.redColor(), animDuration: 0.5, animDelay: 0)
         
@@ -39,18 +39,18 @@ class TargetExample: UIViewController {
             return ChartPointTargetingView(chartPoint: chartPointModel.chartPoint, screenLoc: chartPointModel.screenLoc, animDuration: 0.5, animDelay: 1, frame: chart.bounds, layer: layer)
         }
         
-        let chartPointsTargetLayer = ChartPointsViewsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: targetGenerator)
+        let chartPointsTargetLayer = ChartPointsViewsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: targetGenerator)
         
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLineLayer,
                 chartPointsTargetLayer

--- a/Examples/Examples/TrackerExample.swift
+++ b/Examples/Examples/TrackerExample.swift
@@ -28,23 +28,23 @@ class TrackerExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         let lineModel = ChartLineModel(chartPoints: chartPoints, lineColor: UIColor.redColor(), animDuration: 1, animDelay: 0)
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         
         
         let trackerLayerSettings = ChartPointsLineTrackerLayerSettings(thumbSize: Env.iPad ? 30 : 20, thumbCornerRadius: Env.iPad ? 16 : 10, thumbBorderWidth: Env.iPad ? 4 : 2, infoViewFont: ExamplesDefaults.fontWithSize(Env.iPad ? 26 : 16), infoViewSize: CGSizeMake(Env.iPad ? 400 : 160, Env.iPad ? 70 : 40), infoViewCornerRadius: Env.iPad ? 30 : 15)
-        let chartPointsTrackerLayer = ChartPointsLineTrackerLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, lineColor: UIColor.blackColor(), animDuration: 1, animDelay: 2, settings: trackerLayerSettings)
+        let chartPointsTrackerLayer = ChartPointsLineTrackerLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, chartPoints: chartPoints, lineColor: UIColor.blackColor(), animDuration: 1, animDelay: 2, settings: trackerLayerSettings)
         
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLineLayer,
                 chartPointsTrackerLayer

--- a/Examples/Examples/TrendlineExample.swift
+++ b/Examples/Examples/TrendlineExample.swift
@@ -31,20 +31,20 @@ class TrendlineExample: UIViewController {
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: "Axis title", settings: labelSettings.defaultVertical()))
         let chartFrame = ExamplesDefaults.chartFrame(self.view.bounds)
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: ExamplesDefaults.chartSettings, chartFrame: chartFrame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+        let chartPointsLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
 
-        let trendLineLayer = ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [trendLineModel])
+        let trendLineLayer = ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [trendLineModel])
 
         let settings = ChartGuideLinesDottedLayerSettings(linesColor: UIColor.blackColor(), linesWidth: ExamplesDefaults.guidelinesWidth)
-        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings)
+        let guidelinesLayer = ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, settings: settings)
         
         let chart = Chart(
             frame: chartFrame,
             layers: [
-                xAxis,
-                yAxis,
+                xAxisLayer,
+                yAxisLayer,
                 guidelinesLayer,
                 chartPointsLineLayer,
                 trendLineLayer

--- a/SwiftCharts.xcodeproj/project.pbxproj
+++ b/SwiftCharts.xcodeproj/project.pbxproj
@@ -185,6 +185,9 @@
 		EB08E2331B93A15E0030081C /* ChartAxisValueDouble.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB08E2321B93A15E0030081C /* ChartAxisValueDouble.swift */; };
 		EB4CE97F1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4CE97E1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift */; };
 		EB9B7E6B1BB8A575001B89D4 /* StraightLinePathGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9B7E6A1BB8A575001B89D4 /* StraightLinePathGenerator.swift */; };
+		EB9C88A31D1F365D003C19D1 /* ChartAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C88A21D1F365D003C19D1 /* ChartAxis.swift */; };
+		EB9C88A51D2061F0003C19D1 /* ChartAxisX.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C88A41D2061F0003C19D1 /* ChartAxisX.swift */; };
+		EB9C88A71D2061FA003C19D1 /* ChartAxisY.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C88A61D2061FA003C19D1 /* ChartAxisY.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -323,6 +326,9 @@
 		EB08E2321B93A15E0030081C /* ChartAxisValueDouble.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisValueDouble.swift; sourceTree = "<group>"; };
 		EB4CE97E1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisValueDoubleScreenLoc.swift; sourceTree = "<group>"; };
 		EB9B7E6A1BB8A575001B89D4 /* StraightLinePathGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StraightLinePathGenerator.swift; sourceTree = "<group>"; };
+		EB9C88A21D1F365D003C19D1 /* ChartAxis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxis.swift; sourceTree = "<group>"; };
+		EB9C88A41D2061F0003C19D1 /* ChartAxisX.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisX.swift; sourceTree = "<group>"; };
+		EB9C88A61D2061FA003C19D1 /* ChartAxisY.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisY.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -490,6 +496,9 @@
 				06405DCB1B8AA81D00A689FF /* ChartAxisYHighLayerDefault.swift */,
 				06405DCC1B8AA81D00A689FF /* ChartAxisYLayerDefault.swift */,
 				06405DCD1B8AA81D00A689FF /* ChartAxisYLowLayerDefault.swift */,
+				EB9C88A21D1F365D003C19D1 /* ChartAxis.swift */,
+				EB9C88A41D2061F0003C19D1 /* ChartAxisX.swift */,
+				EB9C88A61D2061FA003C19D1 /* ChartAxisY.swift */,
 			);
 			path = Axis;
 			sourceTree = "<group>";
@@ -796,6 +805,7 @@
 			files = (
 				06405E411B8AA81D00A689FF /* ChartStackedBarsLayer.swift in Sources */,
 				06405E281B8AA81D00A689FF /* ChartConfig.swift in Sources */,
+				EB9C88A51D2061F0003C19D1 /* ChartAxisX.swift in Sources */,
 				06405E351B8AA81D00A689FF /* ChartLayerBase.swift in Sources */,
 				06405E261B8AA81D00A689FF /* ChartViewsConflictSolver.swift in Sources */,
 				06405E381B8AA81D00A689FF /* ChartPointsCandleStickViewsLayer.swift in Sources */,
@@ -808,6 +818,7 @@
 				06405E3D1B8AA81D00A689FF /* ChartPointsSingleViewLayer.swift in Sources */,
 				06405E431B8AA81D00A689FF /* ChartAreasView.swift in Sources */,
 				06405E3B1B8AA81D00A689FF /* ChartPointsLineTrackerLayer.swift in Sources */,
+				EB9C88A31D1F365D003C19D1 /* ChartAxis.swift in Sources */,
 				06405E221B8AA81D00A689FF /* ChartPoint.swift in Sources */,
 				06405E101B8AA81D00A689FF /* ChartAxisLayerDefault.swift in Sources */,
 				06405E341B8AA81D00A689FF /* ChartLayer.swift in Sources */,
@@ -832,6 +843,7 @@
 				06405E4C1B8AA81D00A689FF /* CubicLinePathGenerator.swift in Sources */,
 				06405E2D1B8AA81D00A689FF /* ChartLineDrawer.swift in Sources */,
 				06405E151B8AA81D00A689FF /* ChartAxisXLowLayerDefault.swift in Sources */,
+				EB9C88A71D2061FA003C19D1 /* ChartAxisY.swift in Sources */,
 				06405E3A1B8AA81D00A689FF /* ChartPointsLineLayer.swift in Sources */,
 				06405E231B8AA81D00A689FF /* ChartPointBubble.swift in Sources */,
 				06405E3C1B8AA81D00A689FF /* ChartPointsScatterLayer.swift in Sources */,

--- a/SwiftCharts/Axis/ChartAxis.swift
+++ b/SwiftCharts/Axis/ChartAxis.swift
@@ -1,0 +1,56 @@
+//
+//  ChartAxis.swift
+//  SwiftCharts
+//
+//  Created by ischuetz on 25/06/16.
+//  Copyright © 2016 ivanschuetz. All rights reserved.
+//
+
+import UIKit
+
+public class ChartAxis {
+    
+    /// First model value
+    public let first: Double
+    
+    /// Last model value
+    public let last: Double
+    
+    // Screen location (relative to chart view's frame) corresponding to first model value
+    public let firstScreen: CGFloat
+    
+    // Screen location (relative to chart view's frame) corresponding to last model value
+    public let lastScreen: CGFloat
+
+    // The space between first and last model values. Can be negative (used for mirrored axes)
+    public var modelLength: Double {
+        fatalError("override")
+    }
+
+    // The space between first and last screen locations. Can be negative (used for mirrored axes)
+    public var length: CGFloat {
+        fatalError("override")
+    }
+
+    public init(first: Double, last: Double, firstScreen: CGFloat, lastScreen: CGFloat) {
+        self.first = first
+        self.last = last
+        self.firstScreen = firstScreen
+        self.lastScreen = lastScreen
+    }
+ 
+    /// Calculates screen location (relative to chart view's frame) of model value. It's not required that scalar is between first and last model values.
+    public func screenLocForScalar(scalar: Double) -> CGFloat {
+        fatalError("Override")
+    }
+    
+    /// Calculates model value corresponding to screen location (relative to chart view's frame). It's not required that screenLoc is between firstScreen and lastScreen values.
+    public func scalarForScreenLoc(screenLoc: CGFloat) -> Double {
+        fatalError("Override")
+    }
+    
+    /// Calculates screen location (relative to axis length) of model value. It's not required that scalar is between first and last model values.
+    func innerScreenLocForScalar(scalar: Double) -> CGFloat {
+        return length * CGFloat(scalar - first) / CGFloat(modelLength)
+    }
+}

--- a/SwiftCharts/Axis/ChartAxisLayer.swift
+++ b/SwiftCharts/Axis/ChartAxisLayer.swift
@@ -8,51 +8,32 @@
 
 import UIKit
 
-/// A protocol for all axis layers
 public protocol ChartAxisLayer: ChartLayer {
 
-    /// The location of the smallest axis value
-    var p1: CGPoint {get}
+    // Axis, used to map between model values and screen locations
+    var axis: ChartAxis {get}
 
-    /// The location of the largest axis value
-    var p2: CGPoint {get}
-
-    /// The axis values shown in the layer
+    /// Displayed axis values
     var axisValues: [ChartAxisValue] {get}
 
-    /// The bounding rectangle of the layer. This should take into account all labels, their rotation and any spacing between them
-    var rect: CGRect {get}
+    /// The frame of the layer. This includes title, labels and line, and takes into account possible rotation and spacing settings.
+    var frame: CGRect {get}
 
-    /// The screen locations that corresponds with the axis values
+    /// Screen locations of current axis values
     var axisValuesScreenLocs: [CGFloat] {get}
 
     /// The axis values with their respective frames relative to the chart's view
     var axisValuesWithFrames: [(axisValue: ChartAxisValue, frames: [CGRect])] {get}
     
-    /// The screen locations that correspond with the visible axis values
+    /// Screen locations of current visible axis values (excludes axis values marked explictly as hidden)
     var visibleAxisValuesScreenLocs: [CGFloat] {get}
 
     /// The smallest screen distance between axis values
     var minAxisScreenSpace: CGFloat {get}
-
-    /// The length of the axis along its dimension
-    var length: CGFloat {get}
-
-    /// The difference between the first and last axis values
-    var modelLength: CGFloat {get}
 
     /// Whether the axis is low (leading or bottom) or high (trailing or top)
     var low: Bool {get}
 
     var lineP1: CGPoint {get}
     var lineP2: CGPoint {get}
-
-    /**
-     Calculates the location along the axis dimension for a given axis value's scalar value to be displayed
-
-     - parameter scalar: An axis value's scalar value
-
-     - returns: The location along the axis' dimension that the axis value should be displayed
-     */
-    func screenLocForScalar(scalar: Double) -> CGFloat
 }

--- a/SwiftCharts/Axis/ChartAxisX.swift
+++ b/SwiftCharts/Axis/ChartAxisX.swift
@@ -1,0 +1,28 @@
+//
+//  ChartAxisX.swift
+//  SwiftCharts
+//
+//  Created by ischuetz on 26/06/16.
+//  Copyright © 2016 ivanschuetz. All rights reserved.
+//
+
+import UIKit
+
+public class ChartAxisX: ChartAxis {
+    
+    public override var length: CGFloat {
+        return lastScreen - firstScreen
+    }
+    
+    public override var modelLength: Double {
+        return last - first
+    }
+    
+    public override func screenLocForScalar(scalar: Double) -> CGFloat {
+        return firstScreen + innerScreenLocForScalar(scalar)
+    }
+    
+    public override func scalarForScreenLoc(screenLoc: CGFloat) -> Double {
+        return (Double(screenLoc - firstScreen) * modelLength / Double(length)) + first
+    }
+}

--- a/SwiftCharts/Axis/ChartAxisXHighLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisXHighLayerDefault.swift
@@ -15,12 +15,12 @@ class ChartAxisXHighLayerDefault: ChartAxisXLayerDefault {
 
     /// The start point of the axis line.
     override var lineP1: CGPoint {
-        return CGPointMake(self.p1.x, self.p1.y + self.lineOffset)
+        return CGPointMake(self.origin.x, self.origin.y + self.lineOffset)
     }
 
     /// The end point of the axis line
     override var lineP2: CGPoint {
-        return CGPointMake(self.p2.x, self.p2.y + self.lineOffset)
+        return CGPointMake(self.end.x, self.end.y + self.lineOffset)
     }
 
     /// The offset of the axis labels from the edge of the axis bounds

--- a/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisXLayerDefault.swift
@@ -12,7 +12,7 @@ import UIKit
 class ChartAxisXLayerDefault: ChartAxisLayerDefault {
    
     override var width: CGFloat {
-        return self.p2.x - self.p1.x
+        return self.end.x - self.origin.x
     }
     
     lazy var labelsTotalHeight: CGFloat = {
@@ -28,18 +28,14 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
     override var height: CGFloat {
         return self.labelsTotalHeight + self.settings.axisStrokeWidth + self.settings.labelsToAxisSpacingX + self.settings.axisTitleLabelsToLabelsSpacing + self.axisTitleLabelsHeight
     }
-    
-    override var length: CGFloat {
-        return p2.x - p1.x
-    }
-    
+
     override func chartViewDrawing(context context: CGContextRef, chart: Chart) {
         super.chartViewDrawing(context: context, chart: chart)
     }
     
     override func generateLineDrawer(offset offset: CGFloat) -> ChartLineDrawer {
-        let p1 = CGPointMake(self.p1.x, self.p1.y + offset)
-        let p2 = CGPointMake(self.p2.x, self.p2.y + offset)
+        let p1 = CGPointMake(self.origin.x, self.origin.y + offset)
+        let p2 = CGPointMake(self.end.x, self.end.y + offset)
         return ChartLineDrawer(p1: p1, p2: p2, color: self.settings.lineColor, strokeWidth: self.settings.axisStrokeWidth)
     }
     
@@ -57,18 +53,13 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
             let rowY = self.calculateRowY(rowHeights: rowHeights, rowIndex: index, spacing: spacingLabelBetweenAxis)
             
             let labelWidth = ChartUtils.textSize(label.text, font: label.settings.font).width
-            let x = (self.p2.x - self.p1.x) / 2 + self.p1.x - labelWidth / 2
-            let y = self.p1.y + offset + rowY
+            let x = (self.end.x - self.origin.x) / 2 + self.origin.x - labelWidth / 2
+            let y = self.origin.y + offset + rowY
             
             let drawer = ChartLabelDrawer(text: label.text, screenLoc: CGPointMake(x, y), settings: label.settings)
             drawer.hidden = label.hidden
             return drawer
         }
-    }
-    
-    
-    override func screenLocForScalar(scalar: Double, firstAxisScalar: Double) -> CGFloat {
-        return self.p1.x + self.innerScreenLocForScalar(scalar, firstAxisScalar: firstAxisScalar)
     }
     
     // calculate row heights (max text height) for each row
@@ -100,8 +91,8 @@ class ChartAxisXLayerDefault: ChartAxisLayerDefault {
             let labelDrawers: [ChartLabelDrawer] = axisValue.labels.enumerate().map {index, label in
                 let rowY = self.calculateRowY(rowHeights: rowHeights, rowIndex: index, spacing: spacingLabelBetweenAxis)
                 
-                let x = self.screenLocForScalar(axisValue.scalar)
-                let y = self.p1.y + offset + rowY
+                let x = self.axis.screenLocForScalar(axisValue.scalar)
+                let y = self.origin.y + offset + rowY
                 
                 let labelSize = ChartUtils.textSize(label.text, font: label.settings.font)
                 let labelX = x - (labelSize.width / 2)

--- a/SwiftCharts/Axis/ChartAxisXLowLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisXLowLayerDefault.swift
@@ -15,12 +15,12 @@ class ChartAxisXLowLayerDefault: ChartAxisXLayerDefault {
 
     /// The start point of the axis line.
     override var lineP1: CGPoint {
-        return self.p1
+        return self.origin
     }
 
     /// The end point of the axis line.
     override var lineP2: CGPoint {
-        return self.p2
+        return self.end
     }
     
     override func chartViewDrawing(context context: CGContextRef, chart: Chart) {

--- a/SwiftCharts/Axis/ChartAxisY.swift
+++ b/SwiftCharts/Axis/ChartAxisY.swift
@@ -1,0 +1,28 @@
+//
+//  ChartAxisY.swift
+//  SwiftCharts
+//
+//  Created by ischuetz on 26/06/16.
+//  Copyright © 2016 ivanschuetz. All rights reserved.
+//
+
+import UIKit
+
+public class ChartAxisY: ChartAxis {
+    
+    public override var length: CGFloat {
+        return firstScreen - lastScreen
+    }
+    
+    public override var modelLength: Double {
+        return last - first
+    }
+    
+    public override func screenLocForScalar(scalar: Double) -> CGFloat {
+        return firstScreen - innerScreenLocForScalar(scalar)
+    }
+    
+    public override func scalarForScreenLoc(screenLoc: CGFloat) -> Double {
+        return (Double(-(screenLoc - firstScreen)) * modelLength / Double(length)) + first
+    }
+}

--- a/SwiftCharts/Axis/ChartAxisYHighLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisYHighLayerDefault.swift
@@ -15,12 +15,12 @@ class ChartAxisYHighLayerDefault: ChartAxisYLayerDefault {
 
     /// The start point of the axis line.
     override var lineP1: CGPoint {
-        return self.p1
+        return self.origin
     }
 
     /// The end point of the axis line.
     override var lineP2: CGPoint {
-        return self.p2
+        return self.end
     }
     
     override func initDrawers() {
@@ -35,9 +35,9 @@ class ChartAxisYHighLayerDefault: ChartAxisYLayerDefault {
     
     override func generateLineDrawer(offset offset: CGFloat) -> ChartLineDrawer {
         let halfStrokeWidth = self.settings.axisStrokeWidth / 2 // we want that the stroke begins at the beginning of the frame, not in the middle of it
-        let x = self.p1.x + offset + halfStrokeWidth
-        let p1 = CGPointMake(x, self.p1.y)
-        let p2 = CGPointMake(x, self.p2.y)
+        let x = self.origin.x + offset + halfStrokeWidth
+        let p1 = CGPointMake(x, self.origin.y)
+        let p2 = CGPointMake(x, self.end.y)
         return ChartLineDrawer(p1: p1, p2: p2, color: self.settings.lineColor, strokeWidth: self.settings.axisStrokeWidth)
     }
     
@@ -45,9 +45,9 @@ class ChartAxisYHighLayerDefault: ChartAxisYLayerDefault {
         var labelsX: CGFloat
         switch textAlignment {
         case .Left, .Default:
-            labelsX = self.p1.x + offset
+            labelsX = self.origin.x + offset
         case .Right:
-            labelsX = self.p1.x + offset + self.labelsMaxWidth - labelWidth
+            labelsX = self.origin.x + offset + self.labelsMaxWidth - labelWidth
         }
         return labelsX
     }

--- a/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisYLayerDefault.swift
@@ -12,7 +12,7 @@ import UIKit
 class ChartAxisYLayerDefault: ChartAxisLayerDefault {
     
     override var height: CGFloat {
-        return self.p2.y - self.p1.y
+        return self.end.y - self.origin.y
     }
     
     var labelsMaxWidth: CGFloat {
@@ -30,10 +30,6 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
     override var width: CGFloat {
         return self.labelsMaxWidth + self.settings.axisStrokeWidth + self.settings.labelsToAxisSpacingY + self.settings.axisTitleLabelsToLabelsSpacing + self.axisTitleLabelsWidth
     }
-    
-    override var length: CGFloat {
-        return p1.y - p2.y
-    }
 
     override func generateAxisTitleLabelsDrawers(offset offset: CGFloat) -> [ChartLabelDrawer] {
         
@@ -47,8 +43,8 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
             let settings = axisLabel.settings
             let newSettings = ChartLabelSettings(font: settings.font, fontColor: settings.fontColor, rotation: settings.rotation, rotationKeep: settings.rotationKeep)
             let axisLabelDrawer = ChartLabelDrawer(text: axisLabel.text, screenLoc: CGPointMake(
-                self.p1.x + offset,
-                self.p2.y + ((self.p1.y - self.p2.y) / 2) - (labelSize.height / 2)), settings: newSettings)
+                self.origin.x + offset,
+                self.end.y + ((self.origin.y - self.end.y) / 2) - (labelSize.height / 2)), settings: newSettings)
             
             return [axisLabelDrawer]
             
@@ -56,12 +52,6 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
             return []
         }
     }
-
-    
-    override func screenLocForScalar(scalar: Double, firstAxisScalar: Double) -> CGFloat {
-        return self.p1.y - self.innerScreenLocForScalar(scalar, firstAxisScalar: firstAxisScalar)
-    }
-    
     
     override func generateLabelDrawers(offset offset: CGFloat) -> [ChartAxisValueLabelDrawers] {
         
@@ -71,7 +61,7 @@ class ChartAxisYLayerDefault: ChartAxisLayerDefault {
         
         for axisValue in axisValues {
             let scalar = axisValue.scalar
-            let y = self.screenLocForScalar(scalar)
+            let y = self.axis.screenLocForScalar(scalar)
             if let axisLabel = axisValue.labels.first { // for now y axis supports only one label x value
                 let labelSize = ChartUtils.textSize(axisLabel.text, font: axisLabel.settings.font)
                 let labelY = y - (labelSize.height / 2)

--- a/SwiftCharts/Axis/ChartAxisYLowLayerDefault.swift
+++ b/SwiftCharts/Axis/ChartAxisYLowLayerDefault.swift
@@ -15,12 +15,12 @@ class ChartAxisYLowLayerDefault: ChartAxisYLayerDefault {
 
     /// The start point of the axis line.
     override var lineP1: CGPoint {
-        return CGPointMake(self.p1.x + self.lineOffset, self.p1.y)
+        return CGPointMake(self.origin.x + self.lineOffset, self.origin.y)
     }
 
     /// The end point of the axis line.
     override var lineP2: CGPoint {
-        return CGPointMake(self.p2.x + self.lineOffset, self.p2.y)
+        return CGPointMake(self.end.x + self.lineOffset, self.end.y)
     }
 
     /// The offset of the axis labels from the edge of the axis bounds
@@ -64,13 +64,13 @@ class ChartAxisYLowLayerDefault: ChartAxisYLayerDefault {
     
     override func generateLineDrawer(offset offset: CGFloat) -> ChartLineDrawer {
         let halfStrokeWidth = self.settings.axisStrokeWidth / 2 // we want that the stroke ends at the end of the frame, not be in the middle of it
-        let p1 = CGPointMake(self.p1.x + offset - halfStrokeWidth, self.p1.y)
-        let p2 = CGPointMake(self.p2.x + offset - halfStrokeWidth, self.p2.y)
+        let p1 = CGPointMake(self.origin.x + offset - halfStrokeWidth, self.origin.y)
+        let p2 = CGPointMake(self.end.x + offset - halfStrokeWidth, self.end.y)
         return ChartLineDrawer(p1: p1, p2: p2, color: self.settings.lineColor, strokeWidth: self.settings.axisStrokeWidth)
     }
 
     override func labelsX(offset offset: CGFloat, labelWidth: CGFloat, textAlignment: ChartLabelTextAlignment) -> CGFloat {
-        let labelsXRight = self.p1.x + offset
+        let labelsXRight = self.origin.x + offset
         var labelsX: CGFloat
         switch textAlignment {
         case .Right, .Default:

--- a/SwiftCharts/Convenience/BarsChart.swift
+++ b/SwiftCharts/Convenience/BarsChart.swift
@@ -39,14 +39,14 @@ public class BarsChart: Chart {
         let xModel = ChartAxisModel(axisValues: xValues, axisTitleLabel: ChartAxisLabel(text: xTitle, settings: chartConfig.xAxisLabelSettings))
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: yTitle, settings: chartConfig.xAxisLabelSettings.defaultVertical()))
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartConfig.chartSettings, chartFrame: frame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
-        let barsLayer: ChartLayer = ChartBarsLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, bars: bars, horizontal: horizontal, barWidth: barWidth, animDuration: animDuration)
+        let barsLayer: ChartLayer = ChartBarsLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, bars: bars, horizontal: horizontal, barWidth: barWidth, animDuration: animDuration)
         
-        let guidelinesLayer = GuidelinesDefaultLayerGenerator.generateOpt(xAxis: xAxis, yAxis: yAxis, chartInnerFrame: innerFrame, guidelinesConfig: chartConfig.guidelinesConfig)
+        let guidelinesLayer = GuidelinesDefaultLayerGenerator.generateOpt(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, chartInnerFrame: innerFrame, guidelinesConfig: chartConfig.guidelinesConfig)
         
         let view = ChartBaseView(frame: frame)
-        let layers: [ChartLayer] = [xAxis, yAxis] + (guidelinesLayer.map{[$0]} ?? []) + [barsLayer]
+        let layers: [ChartLayer] = [xAxisLayer, yAxisLayer] + (guidelinesLayer.map{[$0]} ?? []) + [barsLayer]
       
         super.init(
             view: view,

--- a/SwiftCharts/Convenience/ChartConfig.swift
+++ b/SwiftCharts/Convenience/ChartConfig.swift
@@ -65,22 +65,22 @@ public struct GuidelinesConfig {
 // Helper to generate default guidelines layer for GuidelinesConfig
 public struct GuidelinesDefaultLayerGenerator {
 
-    public static func generateOpt(xAxis xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, guidelinesConfig: GuidelinesConfig?) -> ChartLayer? {
+    public static func generateOpt(xAxisLayer xAxisLayer: ChartAxisLayer, yAxisLayer: ChartAxisLayer, chartInnerFrame: CGRect, guidelinesConfig: GuidelinesConfig?) -> ChartLayer? {
         if let guidelinesConfig = guidelinesConfig {
-            return self.generate(xAxis: xAxis, yAxis: yAxis, chartInnerFrame: chartInnerFrame, guidelinesConfig: guidelinesConfig)
+            return self.generate(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, chartInnerFrame: chartInnerFrame, guidelinesConfig: guidelinesConfig)
         } else {
             return nil
         }
     }
     
-    public static func generate(xAxis xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, guidelinesConfig: GuidelinesConfig) -> ChartLayer {
+    public static func generate(xAxisLayer xAxisLayer: ChartAxisLayer, yAxisLayer: ChartAxisLayer, chartInnerFrame: CGRect, guidelinesConfig: GuidelinesConfig) -> ChartLayer {
         if guidelinesConfig.dotted {
             let settings = ChartGuideLinesDottedLayerSettings(linesColor: guidelinesConfig.lineColor, linesWidth: guidelinesConfig.lineWidth)
-            return ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, settings: settings)
+            return ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: chartInnerFrame, settings: settings)
             
         } else {
             let settings = ChartGuideLinesDottedLayerSettings(linesColor: guidelinesConfig.lineColor, linesWidth: guidelinesConfig.lineWidth)
-            return ChartGuideLinesDottedLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: chartInnerFrame, settings: settings)
+            return ChartGuideLinesDottedLayer(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: chartInnerFrame, settings: settings)
         }
     }
 }

--- a/SwiftCharts/Convenience/LineChart.swift
+++ b/SwiftCharts/Convenience/LineChart.swift
@@ -26,7 +26,7 @@ public class LineChart: Chart {
         let xModel = ChartAxisModel(axisValues: xValues, axisTitleLabel: ChartAxisLabel(text: xTitle, settings: chartConfig.xAxisLabelSettings))
         let yModel = ChartAxisModel(axisValues: yValues, axisTitleLabel: ChartAxisLabel(text: yTitle, settings: chartConfig.yAxisLabelSettings.defaultVertical()))
         let coordsSpace = ChartCoordsSpaceLeftBottomSingleAxis(chartSettings: chartConfig.chartSettings, chartFrame: frame, xModel: xModel, yModel: yModel)
-        let (xAxis, yAxis, innerFrame) = (coordsSpace.xAxis, coordsSpace.yAxis, coordsSpace.chartInnerFrame)
+        let (xAxisLayer, yAxisLayer, innerFrame) = (coordsSpace.xAxisLayer, coordsSpace.yAxisLayer, coordsSpace.chartInnerFrame)
         
         let lineLayers: [ChartLayer] = lines.map {line in
             let chartPoints = line.chartPoints.map {chartPointScalar in
@@ -34,13 +34,13 @@ public class LineChart: Chart {
             }
             
             let lineModel = ChartLineModel(chartPoints: chartPoints, lineColor: line.color, animDuration: 0.5, animDelay: 0)
-            return ChartPointsLineLayer(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, lineModels: [lineModel])
+            return ChartPointsLineLayer(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame, lineModels: [lineModel])
         }
         
-        let guidelinesLayer = GuidelinesDefaultLayerGenerator.generateOpt(xAxis: xAxis, yAxis: yAxis, chartInnerFrame: innerFrame, guidelinesConfig: chartConfig.guidelinesConfig)
+        let guidelinesLayer = GuidelinesDefaultLayerGenerator.generateOpt(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, chartInnerFrame: innerFrame, guidelinesConfig: chartConfig.guidelinesConfig)
         
         let view = ChartBaseView(frame: frame)
-        let layers: [ChartLayer] = [xAxis, yAxis] + (guidelinesLayer.map{[$0]} ?? []) + lineLayers
+        let layers: [ChartLayer] = [xAxisLayer, yAxisLayer] + (guidelinesLayer.map{[$0]} ?? []) + lineLayers
         
         super.init(
             view: view,

--- a/SwiftCharts/Layers/ChartBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartBarsLayer.swift
@@ -28,52 +28,31 @@ public class ChartBarModel {
     }
 }
 
-enum ChartBarDirection {
-    case LeftToRight, BottomToTop
-}
-
 class ChartBarsViewGenerator<T: ChartBarModel> {
-    let xAxis: ChartAxisLayer
-    let yAxis: ChartAxisLayer
+    let xAxis: ChartAxis
+    let yAxis: ChartAxis
     let chartInnerFrame: CGRect
-    let direction: ChartBarDirection
     let barWidth: CGFloat
     
-    init(horizontal: Bool, xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, barWidth barWidthMaybe: CGFloat?, barSpacing barSpacingMaybe: CGFloat?) {
-        
-        let direction: ChartBarDirection = {
-            switch (horizontal: horizontal, yLow: yAxis.low, xLow: xAxis.low) {
-            case (horizontal: true, yLow: true, _): return .LeftToRight
-            case (horizontal: false, _, xLow: true): return .BottomToTop
-            default: fatalError("Direction not supported - stacked bars must be from left to right or bottom to top")
-            }
-        }()
-        
-        let barWidth = barWidthMaybe ?? {
-            let axis: ChartAxisLayer = {
-                switch direction {
-                case .LeftToRight: return yAxis
-                case .BottomToTop: return xAxis
-                }
-                }()
-            let spacing: CGFloat = barSpacingMaybe ?? 0
-            return axis.minAxisScreenSpace - spacing
-        }()
-        
+    let horizontal: Bool
+    
+    init(horizontal: Bool, xAxis: ChartAxis, yAxis: ChartAxis, chartInnerFrame: CGRect, barWidth: CGFloat) {
+        self.horizontal = horizontal
         self.xAxis = xAxis
         self.yAxis = yAxis
         self.chartInnerFrame = chartInnerFrame
-        self.direction = direction
         self.barWidth = barWidth
     }
     
     func viewPoints(barModel: T, constantScreenLoc: CGFloat) -> (p1: CGPoint, p2: CGPoint) {
-        switch self.direction {
-        case .LeftToRight:
+
+        
+        switch self.horizontal {
+        case true:
             return (
                 CGPointMake(self.xAxis.screenLocForScalar(barModel.axisValue1.scalar), constantScreenLoc),
                 CGPointMake(self.xAxis.screenLocForScalar(barModel.axisValue2.scalar), constantScreenLoc))
-        case .BottomToTop:
+        case false:
             return (
                 CGPointMake(constantScreenLoc, self.yAxis.screenLocForScalar(barModel.axisValue1.scalar)),
                 CGPointMake(constantScreenLoc, self.yAxis.screenLocForScalar(barModel.axisValue2.scalar)))
@@ -81,7 +60,7 @@ class ChartBarsViewGenerator<T: ChartBarModel> {
     }
     
     func constantScreenLoc(barModel: T) -> CGFloat {
-        return (self.direction == .LeftToRight ? self.yAxis : self.xAxis).screenLocForScalar(barModel.constant.scalar)
+        return (self.horizontal ? self.yAxis : self.xAxis).screenLocForScalar(barModel.constant.scalar)
     }
     
     // constantScreenLoc: (screen) coordinate that is equal in p1 and p2 - for vertical bar this is the x coordinate, for horizontal bar this is the y coordinate
@@ -97,29 +76,15 @@ class ChartBarsViewGenerator<T: ChartBarModel> {
 
 
 public class ChartBarsLayer: ChartCoordsSpaceLayer {
-    
     private let bars: [ChartBarModel]
-    
-    private let barWidth: CGFloat?
-    private let barSpacing: CGFloat?
-    
+    private let barWidth: CGFloat
     private let horizontal: Bool
-    
     private let animDuration: Float
     
-    public convenience init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, bars: [ChartBarModel], horizontal: Bool = false, barWidth: CGFloat, animDuration: Float) {
-        self.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, bars: bars, horizontal: horizontal, barWidth: barWidth, barSpacing: nil, animDuration: animDuration)
-    }
-    
-    public convenience init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, bars: [ChartBarModel], horizontal: Bool = false, barSpacing: CGFloat, animDuration: Float) {
-        self.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, bars: bars, horizontal: horizontal, barWidth: nil, barSpacing: barSpacing, animDuration: animDuration)
-    }
-    
-    private init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, bars: [ChartBarModel], horizontal: Bool = false, barWidth: CGFloat? = nil, barSpacing: CGFloat?, animDuration: Float) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, bars: [ChartBarModel], horizontal: Bool = false, barWidth: CGFloat, animDuration: Float) {
         self.bars = bars
         self.horizontal = horizontal
         self.barWidth = barWidth
-        self.barSpacing = barSpacing
         self.animDuration = animDuration
 
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame)
@@ -127,8 +92,7 @@ public class ChartBarsLayer: ChartCoordsSpaceLayer {
     
     public override func chartInitialized(chart chart: Chart) {
         
-        
-        let barsGenerator = ChartBarsViewGenerator(horizontal: self.horizontal, xAxis: self.xAxis, yAxis: self.yAxis, chartInnerFrame: self.innerFrame, barWidth: self.barWidth, barSpacing: self.barSpacing)
+        let barsGenerator = ChartBarsViewGenerator(horizontal: self.horizontal, xAxis: self.xAxis, yAxis: self.yAxis, chartInnerFrame: self.innerFrame, barWidth: self.barWidth)
         
         for barModel in self.bars {
             chart.addSubview(barsGenerator.generateView(barModel, bgColor: barModel.bgColor, animDuration: self.animDuration))

--- a/SwiftCharts/Layers/ChartCandleStickLayer.swift
+++ b/SwiftCharts/Layers/ChartCandleStickLayer.swift
@@ -15,7 +15,7 @@ public class ChartCandleStickLayer<T: ChartPointCandleStick>: ChartPointsLayer<T
     private let itemWidth: CGFloat
     private let strokeWidth: CGFloat
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], itemWidth: CGFloat = 10, strokeWidth: CGFloat = 1) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], itemWidth: CGFloat = 10, strokeWidth: CGFloat = 1) {
         self.itemWidth = itemWidth
         self.strokeWidth = strokeWidth
         

--- a/SwiftCharts/Layers/ChartCoordsSpaceLayer.swift
+++ b/SwiftCharts/Layers/ChartCoordsSpaceLayer.swift
@@ -10,14 +10,13 @@ import UIKit
 
 public class ChartCoordsSpaceLayer: ChartLayerBase {
     
-    let xAxis: ChartAxisLayer
-    let yAxis: ChartAxisLayer
+    let xAxis: ChartAxis
+    let yAxis: ChartAxis
     
     // frame where the layer displays chartpoints
-    // note that this is not necessarily derived from axis, as axis can be in different positions (x-left/right, y-top/bottom) and be separated from content frame by a specified offset (multiaxis)
     public let innerFrame: CGRect
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect) {
         self.xAxis = xAxis
         self.yAxis = yAxis
         self.innerFrame = innerFrame

--- a/SwiftCharts/Layers/ChartDividersLayer.swift
+++ b/SwiftCharts/Layers/ChartDividersLayer.swift
@@ -37,19 +37,25 @@ public class ChartDividersLayer: ChartCoordsSpaceLayer {
     
     let axis: ChartDividersLayerAxis
 
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, axis: ChartDividersLayerAxis = .XAndY, settings: ChartDividersLayerSettings) {
+    private let xAxisLayer: ChartAxisLayer
+    private let yAxisLayer: ChartAxisLayer
+    
+    public init(xAxisLayer: ChartAxisLayer, yAxisLayer: ChartAxisLayer, innerFrame: CGRect, axis: ChartDividersLayerAxis = .XAndY, settings: ChartDividersLayerSettings) {
         self.axis = axis
         self.settings = settings
         
+        self.xAxisLayer = xAxisLayer
+        self.yAxisLayer = yAxisLayer
+        
         func screenLocs(axisLayer: ChartAxisLayer) -> [CGFloat] {
             let values = settings.onlyVisibleValues ? axisLayer.axisValues.filter{!$0.hidden} : axisLayer.axisValues
-            return values.map{axisLayer.screenLocForScalar($0.scalar)}
+            return values.map{axisLayer.axis.screenLocForScalar($0.scalar)}
         }
         
-        self.xScreenLocs = screenLocs(xAxis)
-        self.yScreenLocs = screenLocs(yAxis)
+        self.xScreenLocs = screenLocs(xAxisLayer)
+        self.yScreenLocs = screenLocs(yAxisLayer)
         
-        super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame)
+        super.init(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame)
     }
     
     private func drawLine(context context: CGContextRef, color: UIColor, width: CGFloat, p1: CGPoint, p2: CGPoint) {
@@ -63,18 +69,18 @@ public class ChartDividersLayer: ChartCoordsSpaceLayer {
         if self.axis == .X || self.axis == .XAndY {
             for xScreenLoc in xScreenLocs {
                 let x1 = xScreenLoc
-                let y1 = self.xAxis.lineP1.y + (self.xAxis.low ? -self.settings.end : self.settings.end)
+                let y1 = self.xAxisLayer.lineP1.y + (self.xAxisLayer.low ? -self.settings.end : self.settings.end)
                 let x2 = xScreenLoc
-                let y2 = self.xAxis.lineP1.y + (self.xAxis.low ? self.settings.start : -self.settings.start)
+                let y2 = self.xAxisLayer.lineP1.y + (self.xAxisLayer.low ? self.settings.start : -self.settings.start)
                 self.drawLine(context: context, color: self.settings.linesColor, width: self.settings.linesWidth, p1: CGPointMake(x1, y1), p2: CGPointMake(x2, y2))
             }
         }
         
         if self.axis == .Y || self.axis == .XAndY {
             for yScreenLoc in yScreenLocs {
-                let x1 = self.yAxis.lineP1.x + (self.yAxis.low ? -self.settings.start : self.settings.start)
+                let x1 = self.yAxisLayer.lineP1.x + (self.yAxisLayer.low ? -self.settings.start : self.settings.start)
                 let y1 = yScreenLoc
-                let x2 = self.yAxis.lineP1.x + (self.yAxis.low ? self.settings.end : self.settings.end)
+                let x2 = self.yAxisLayer.lineP1.x + (self.yAxisLayer.low ? self.settings.end : self.settings.end)
                 let y2 = yScreenLoc
                 self.drawLine(context: context, color: self.settings.linesColor, width: self.settings.linesWidth, p1: CGPointMake(x1, y1), p2: CGPointMake(x2, y2))
             }

--- a/SwiftCharts/Layers/ChartGroupedBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartGroupedBarsLayer.swift
@@ -30,7 +30,7 @@ public class ChartGroupedBarsLayer<T: ChartBarModel>: ChartCoordsSpaceLayer {
     
     private let animDuration: Float
 
-    init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, groups: [ChartPointsBarGroup<T>], horizontal: Bool = false, barSpacing: CGFloat?, groupSpacing: CGFloat?, animDuration: Float) {
+    init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, groups: [ChartPointsBarGroup<T>], horizontal: Bool = false, barSpacing: CGFloat?, groupSpacing: CGFloat?, animDuration: Float) {
         self.groups = groups
         self.horizontal = horizontal
         self.barSpacing = barSpacing
@@ -56,7 +56,7 @@ public class ChartGroupedBarsLayer<T: ChartBarModel>: ChartCoordsSpaceLayer {
 
         let barsGenerator = self.barsGenerator(barWidth: barWidth)
         
-        let calculateConstantScreenLoc: (axis: ChartAxisLayer, index: Int, group: ChartPointsBarGroup<T>) -> CGFloat = {axis, index, group in
+        let calculateConstantScreenLoc: (axis: ChartAxis, index: Int, group: ChartPointsBarGroup<T>) -> CGFloat = {axis, index, group in
             let totalWidth = CGFloat(group.bars.count) * barWidth + ((self.barSpacing ?? 0) * (maxBarCountInGroup - 1))
             let groupCenter = axis.screenLocForScalar(group.constant.scalar)
             let origin = groupCenter - totalWidth / 2
@@ -68,7 +68,7 @@ public class ChartGroupedBarsLayer<T: ChartBarModel>: ChartCoordsSpaceLayer {
             for (index, bar) in group.bars.enumerate() {
                 
                 let constantScreenLoc: CGFloat = {
-                    if barsGenerator.direction == .LeftToRight {
+                    if barsGenerator.horizontal {
                         return calculateConstantScreenLoc(axis: self.yAxis, index: index, group: group)
                     } else {
                         return calculateConstantScreenLoc(axis: self.xAxis, index: index, group: group)
@@ -85,23 +85,23 @@ public class ChartGroupedBarsLayer<T: ChartBarModel>: ChartCoordsSpaceLayer {
 public typealias ChartGroupedPlainBarsLayer = ChartGroupedPlainBarsLayer_<Any>
 public class ChartGroupedPlainBarsLayer_<N>: ChartGroupedBarsLayer<ChartBarModel> {
 
-    public override init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, groups: [ChartPointsBarGroup<ChartBarModel>], horizontal: Bool, barSpacing: CGFloat?, groupSpacing: CGFloat?, animDuration: Float) {
+    public override init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, groups: [ChartPointsBarGroup<ChartBarModel>], horizontal: Bool, barSpacing: CGFloat?, groupSpacing: CGFloat?, animDuration: Float) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, groups: groups, horizontal: horizontal, barSpacing: barSpacing, groupSpacing: groupSpacing, animDuration: animDuration)
     }
     
     override func barsGenerator(barWidth barWidth: CGFloat) -> ChartBarsViewGenerator<ChartBarModel> {
-        return ChartBarsViewGenerator(horizontal: self.horizontal, xAxis: self.xAxis, yAxis: self.yAxis, chartInnerFrame: self.innerFrame, barWidth: barWidth, barSpacing: self.barSpacing)
+        return ChartBarsViewGenerator(horizontal: self.horizontal, xAxis: self.xAxis, yAxis: self.yAxis, chartInnerFrame: self.innerFrame, barWidth: barWidth)
     }
 }
 
 public typealias ChartGroupedStackedBarsLayer = ChartGroupedStackedBarsLayer_<Any>
 public class ChartGroupedStackedBarsLayer_<N>: ChartGroupedBarsLayer<ChartStackedBarModel> {
     
-    public override init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, groups: [ChartPointsBarGroup<ChartStackedBarModel>], horizontal: Bool, barSpacing: CGFloat?, groupSpacing: CGFloat?, animDuration: Float) {
+    public override init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, groups: [ChartPointsBarGroup<ChartStackedBarModel>], horizontal: Bool, barSpacing: CGFloat?, groupSpacing: CGFloat?, animDuration: Float) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, groups: groups, horizontal: horizontal, barSpacing: barSpacing, groupSpacing: groupSpacing, animDuration: animDuration)
     }
     
     override func barsGenerator(barWidth barWidth: CGFloat) -> ChartBarsViewGenerator<ChartStackedBarModel> {
-        return ChartStackedBarsViewGenerator(horizontal: horizontal, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: innerFrame, barWidth: barWidth, barSpacing: barSpacing)
+        return ChartStackedBarsViewGenerator(horizontal: horizontal, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: innerFrame, barWidth: barWidth)
     }
 }

--- a/SwiftCharts/Layers/ChartGuideLinesLayer.swift
+++ b/SwiftCharts/Layers/ChartGuideLinesLayer.swift
@@ -39,13 +39,18 @@ public class ChartGuideLinesLayerAbstract<T: ChartGuideLinesLayerSettings>: Char
     private let onlyVisibleX: Bool
     private let onlyVisibleY: Bool
     private let axis: ChartGuideLinesLayerAxis
-    
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, axis: ChartGuideLinesLayerAxis = .XAndY, settings: T, onlyVisibleX: Bool = false, onlyVisibleY: Bool = false) {
+    private let xAxisLayer: ChartAxisLayer
+    private let yAxisLayer: ChartAxisLayer
+
+    public init(xAxisLayer: ChartAxisLayer, yAxisLayer: ChartAxisLayer, innerFrame: CGRect, axis: ChartGuideLinesLayerAxis = .XAndY, settings: T, onlyVisibleX: Bool = false, onlyVisibleY: Bool = false) {
         self.settings = settings
         self.onlyVisibleX = onlyVisibleX
         self.onlyVisibleY = onlyVisibleY
         self.axis = axis
-        super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame)
+        self.xAxisLayer = xAxisLayer
+        self.yAxisLayer = yAxisLayer
+        
+        super.init(xAxis: xAxisLayer.axis, yAxis: yAxisLayer.axis, innerFrame: innerFrame)
     }
     
     private func drawGuideline(context: CGContextRef, p1: CGPoint, p2: CGPoint) {
@@ -54,8 +59,8 @@ public class ChartGuideLinesLayerAbstract<T: ChartGuideLinesLayerSettings>: Char
     
     override public func chartViewDrawing(context context: CGContextRef, chart: Chart) {
         let originScreenLoc = self.innerFrame.origin
-        let xScreenLocs = onlyVisibleX ? self.xAxis.visibleAxisValuesScreenLocs : self.xAxis.axisValuesScreenLocs
-        let yScreenLocs = onlyVisibleY ? self.yAxis.visibleAxisValuesScreenLocs : self.yAxis.axisValuesScreenLocs
+        let xScreenLocs = onlyVisibleX ? self.xAxisLayer.visibleAxisValuesScreenLocs : self.xAxisLayer.axisValuesScreenLocs
+        let yScreenLocs = onlyVisibleY ? self.yAxisLayer.visibleAxisValuesScreenLocs : self.yAxisLayer.axisValuesScreenLocs
         
         if self.axis == .X || self.axis == .XAndY {
             for xScreenLoc in xScreenLocs {
@@ -82,8 +87,8 @@ public class ChartGuideLinesLayerAbstract<T: ChartGuideLinesLayerSettings>: Char
 public typealias ChartGuideLinesLayer = ChartGuideLinesLayer_<Any>
 public class ChartGuideLinesLayer_<N>: ChartGuideLinesLayerAbstract<ChartGuideLinesLayerSettings> {
     
-    override public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, axis: ChartGuideLinesLayerAxis = .XAndY, settings: ChartGuideLinesLayerSettings, onlyVisibleX: Bool = false, onlyVisibleY: Bool = false) {
-        super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, axis: axis, settings: settings, onlyVisibleX: onlyVisibleX, onlyVisibleY: onlyVisibleY)
+    override public init(xAxisLayer: ChartAxisLayer, yAxisLayer: ChartAxisLayer, innerFrame: CGRect, axis: ChartGuideLinesLayerAxis = .XAndY, settings: ChartGuideLinesLayerSettings, onlyVisibleX: Bool = false, onlyVisibleY: Bool = false) {
+        super.init(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, axis: axis, settings: settings, onlyVisibleX: onlyVisibleX, onlyVisibleY: onlyVisibleY)
     }
     
     override private func drawGuideline(context: CGContextRef, p1: CGPoint, p2: CGPoint) {
@@ -94,8 +99,8 @@ public class ChartGuideLinesLayer_<N>: ChartGuideLinesLayerAbstract<ChartGuideLi
 public typealias ChartGuideLinesDottedLayer = ChartGuideLinesDottedLayer_<Any>
 public class ChartGuideLinesDottedLayer_<N>: ChartGuideLinesLayerAbstract<ChartGuideLinesDottedLayerSettings> {
     
-    override public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, axis: ChartGuideLinesLayerAxis = .XAndY, settings: ChartGuideLinesDottedLayerSettings, onlyVisibleX: Bool = false, onlyVisibleY: Bool = false) {
-        super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, axis: axis, settings: settings, onlyVisibleX: onlyVisibleX, onlyVisibleY: onlyVisibleY)
+    override public init(xAxisLayer: ChartAxisLayer, yAxisLayer: ChartAxisLayer, innerFrame: CGRect, axis: ChartGuideLinesLayerAxis = .XAndY, settings: ChartGuideLinesDottedLayerSettings, onlyVisibleX: Bool = false, onlyVisibleY: Bool = false) {
+        super.init(xAxisLayer: xAxisLayer, yAxisLayer: yAxisLayer, innerFrame: innerFrame, axis: axis, settings: settings, onlyVisibleX: onlyVisibleX, onlyVisibleY: onlyVisibleY)
     }
     
     override private func drawGuideline(context: CGContextRef, p1: CGPoint, p2: CGPoint) {
@@ -110,7 +115,7 @@ public class ChartGuideLinesForValuesLayerAbstract<T: ChartGuideLinesLayerSettin
     private let axisValuesX: [ChartAxisValue]
     private let axisValuesY: [ChartAxisValue]
 
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, settings: T, axisValuesX: [ChartAxisValue], axisValuesY: [ChartAxisValue]) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, settings: T, axisValuesX: [ChartAxisValue], axisValuesY: [ChartAxisValue]) {
         self.settings = settings
         self.axisValuesX = axisValuesX
         self.axisValuesY = axisValuesY
@@ -154,7 +159,7 @@ public class ChartGuideLinesForValuesLayerAbstract<T: ChartGuideLinesLayerSettin
 public typealias ChartGuideLinesForValuesLayer = ChartGuideLinesForValuesLayer_<Any>
 public class ChartGuideLinesForValuesLayer_<N>: ChartGuideLinesForValuesLayerAbstract<ChartGuideLinesLayerSettings> {
     
-    public override init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, settings: ChartGuideLinesLayerSettings, axisValuesX: [ChartAxisValue], axisValuesY: [ChartAxisValue]) {
+    public override init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, settings: ChartGuideLinesLayerSettings, axisValuesX: [ChartAxisValue], axisValuesY: [ChartAxisValue]) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings, axisValuesX: axisValuesX, axisValuesY: axisValuesY)
     }
     
@@ -166,7 +171,7 @@ public class ChartGuideLinesForValuesLayer_<N>: ChartGuideLinesForValuesLayerAbs
 public typealias ChartGuideLinesForValuesDottedLayer = ChartGuideLinesForValuesDottedLayer_<Any>
 public class ChartGuideLinesForValuesDottedLayer_<N>: ChartGuideLinesForValuesLayerAbstract<ChartGuideLinesDottedLayerSettings> {
     
-    public override init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, settings: ChartGuideLinesDottedLayerSettings, axisValuesX: [ChartAxisValue], axisValuesY: [ChartAxisValue]) {
+    public override init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, settings: ChartGuideLinesDottedLayerSettings, axisValuesX: [ChartAxisValue], axisValuesY: [ChartAxisValue]) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, settings: settings, axisValuesX: axisValuesX, axisValuesY: axisValuesY)
     }
     

--- a/SwiftCharts/Layers/ChartPointsAreaLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsAreaLayer.swift
@@ -15,7 +15,7 @@ public class ChartPointsAreaLayer<T: ChartPoint>: ChartPointsLayer<T> {
     private let animDelay: Float
     private let addContainerPoints: Bool
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], areaColor: UIColor, animDuration: Float, animDelay: Float, addContainerPoints: Bool) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], areaColor: UIColor, animDuration: Float, animDelay: Float, addContainerPoints: Bool) {
         self.areaColor = areaColor
         self.animDuration = animDuration
         self.animDelay = animDelay

--- a/SwiftCharts/Layers/ChartPointsBubbleLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsBubbleLayer.swift
@@ -12,7 +12,7 @@ public class ChartPointsBubbleLayer<T: ChartPointBubble>: ChartPointsLayer<T> {
     
     private let diameterFactor: Double
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, maxBubbleDiameter: Double = 30, minBubbleDiameter: Double = 2) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, maxBubbleDiameter: Double = 30, minBubbleDiameter: Double = 2) {
         
         let (minDiameterScalar, maxDiameterScalar): (Double, Double) = chartPoints.reduce((min: 0, max: 0)) {tuple, chartPoint in
             (min: min(tuple.min, chartPoint.diameterScalar), max: max(tuple.max, chartPoint.diameterScalar))

--- a/SwiftCharts/Layers/ChartPointsCandleStickViewsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsCandleStickViewsLayer.swift
@@ -10,7 +10,7 @@ import UIKit
 
 public class ChartPointsCandleStickViewsLayer<T: ChartPointCandleStick, U: ChartCandleStickView>: ChartPointsViewsLayer<ChartPointCandleStick, ChartCandleStickView> {
 
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], viewGenerator: ChartPointViewGenerator) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], viewGenerator: ChartPointViewGenerator) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: viewGenerator)
     }
     

--- a/SwiftCharts/Layers/ChartPointsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLayer.swift
@@ -30,7 +30,7 @@ public class ChartPointsLayer<T: ChartPoint>: ChartCoordsSpaceLayer {
         return self.chartPointsModels.map{$0.screenLoc}
     }
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0) {
         self.chartPointsModels = chartPoints.enumerate().map {index, chartPoint in
             let screenLoc = CGPointMake(xAxis.screenLocForScalar(chartPoint.x.scalar), yAxis.screenLocForScalar(chartPoint.y.scalar))
             return ChartPointLayerModel(chartPoint: chartPoint, index: index, screenLoc: screenLoc)

--- a/SwiftCharts/Layers/ChartPointsLineLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLineLayer.swift
@@ -29,7 +29,7 @@ public class ChartPointsLineLayer<T: ChartPoint>: ChartPointsLayer<T> {
     private var lineViews: [ChartLinesView] = []
     private let pathGenerator: ChartLinesViewPathGenerator
 
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, lineModels: [ChartLineModel<T>], pathGenerator: ChartLinesViewPathGenerator = StraightLinePathGenerator(), displayDelay: Float = 0) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, lineModels: [ChartLineModel<T>], pathGenerator: ChartLinesViewPathGenerator = StraightLinePathGenerator(), displayDelay: Float = 0) {
         
         self.lineModels = lineModels
         self.pathGenerator = pathGenerator

--- a/SwiftCharts/Layers/ChartPointsLineTrackerLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsLineTrackerLayer.swift
@@ -61,7 +61,7 @@ public class ChartPointsLineTrackerLayer<T: ChartPoint>: ChartPointsLayer<T> {
     
     private var view: TrackerView?
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], lineColor: UIColor, animDuration: Float, animDelay: Float, settings: ChartPointsLineTrackerLayerSettings) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], lineColor: UIColor, animDuration: Float, animDelay: Float, settings: ChartPointsLineTrackerLayerSettings) {
         self.lineColor = lineColor
         self.animDuration = animDuration
         self.animDelay = animDelay
@@ -163,7 +163,7 @@ public class ChartPointsLineTrackerLayer<T: ChartPoint>: ChartPointsLayer<T> {
 
             // Select point with smallest distance to touch point.
             // If there's only one intersection, returns intersection. If there's no intersection returns nil.
-            var intersectionMaybe: CGPoint? = {
+            let intersectionMaybe: CGPoint? = {
                 var minDistancePoint: (distance: Float, point: CGPoint?) = (MAXFLOAT, nil)
                 for intersection in intersections {
                     let distance = hypotf(Float(intersection.x - touchPoint.x), Float(intersection.y - touchPoint.y))
@@ -189,27 +189,15 @@ public class ChartPointsLineTrackerLayer<T: ChartPoint>: ChartPointsLayer<T> {
                     }, completion: { (Bool) -> Void in
                 })
                 
-                var w: CGFloat = self.settings.thumbSize
-                var h: CGFloat = self.settings.thumbSize
+                let w: CGFloat = self.settings.thumbSize
+                let h: CGFloat = self.settings.thumbSize
                 self.currentPositionLineOverlay.frame = CGRectMake(intersection.x, 0, 1, view.frame.size.height)
                 self.thumb.frame = CGRectMake(intersection.x - w/2, intersection.y - h/2, w, h)
                 
-                // Calculate scalar corresponding to intersection screen location along axis
-                func scalar(axis: ChartAxisLayer, intersection: CGFloat) -> Double {
-                    let s1 = axis.axisValues[0].scalar
-                    let sl1 = axis.screenLocForScalar(s1)
-                    let s2 = axis.axisValues[1].scalar
-                    let sl2 = axis.screenLocForScalar(s2)
-                    
-                    let factor = (s2 - s1) / Double(sl2 - sl1)
-                    let sl = Double(intersection - sl1)
-                    return sl * Double(factor) + Double(s1)
-                }
-                
                 if self.chartPointsModels.count > 1 {
 
-                    let xScalar = scalar(self.xAxis, intersection: intersection.x)
-                    let yScalar = scalar(self.yAxis, intersection: intersection.y)
+                    let xScalar = self.xAxis.scalarForScreenLoc(intersection.x)
+                    let yScalar = self.yAxis.scalarForScreenLoc(intersection.y)
                     
                     let dummyModel = self.chartPointsModels[0]
                     let x = dummyModel.chartPoint.x.copy(xScalar)

--- a/SwiftCharts/Layers/ChartPointsScatterLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsScatterLayer.swift
@@ -13,7 +13,7 @@ public class ChartPointsScatterLayer<T: ChartPoint>: ChartPointsLayer<T> {
     public let itemSize: CGSize
     public let itemFillColor: UIColor
     
-    required public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor) {
+    required public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor) {
         self.itemSize = itemSize
         self.itemFillColor = itemFillColor
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, displayDelay: displayDelay)
@@ -32,7 +32,7 @@ public class ChartPointsScatterLayer<T: ChartPoint>: ChartPointsLayer<T> {
 
 public class ChartPointsScatterTrianglesLayer<T: ChartPoint>: ChartPointsScatterLayer<T> {
     
-    required public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor) {
+    required public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, displayDelay: displayDelay, itemSize: itemSize, itemFillColor: itemFillColor)
     }
     
@@ -54,7 +54,7 @@ public class ChartPointsScatterTrianglesLayer<T: ChartPoint>: ChartPointsScatter
 
 public class ChartPointsScatterSquaresLayer<T: ChartPoint>: ChartPointsScatterLayer<T> {
     
-    required public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor) {
+    required public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, displayDelay: displayDelay, itemSize: itemSize, itemFillColor: itemFillColor)
     }
     
@@ -69,7 +69,7 @@ public class ChartPointsScatterSquaresLayer<T: ChartPoint>: ChartPointsScatterLa
 
 public class ChartPointsScatterCirclesLayer<T: ChartPoint>: ChartPointsScatterLayer<T> {
     
-    required public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor) {
+    required public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, displayDelay: displayDelay, itemSize: itemSize, itemFillColor: itemFillColor)
     }
     
@@ -86,7 +86,7 @@ public class ChartPointsScatterCrossesLayer<T: ChartPoint>: ChartPointsScatterLa
     
     public let strokeWidth: CGFloat
     
-    required public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor, strokeWidth: CGFloat = 2) {
+    required public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], displayDelay: Float = 0, itemSize: CGSize, itemFillColor: UIColor, strokeWidth: CGFloat = 2) {
         self.strokeWidth = strokeWidth
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, displayDelay: displayDelay, itemSize: itemSize, itemFillColor: itemFillColor)
     }

--- a/SwiftCharts/Layers/ChartPointsSingleViewLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsSingleViewLayer.swift
@@ -13,7 +13,7 @@ public class ChartPointsSingleViewLayer<T: ChartPoint, U: UIView>: ChartPointsVi
     
     private var addedViews: [UIView] = []
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], viewGenerator: ChartPointViewGenerator) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], viewGenerator: ChartPointViewGenerator) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, viewGenerator: viewGenerator)
     }
 

--- a/SwiftCharts/Layers/ChartPointsTrackerLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsTrackerLayer.swift
@@ -23,7 +23,7 @@ public class ChartPointsTrackerLayer<T: ChartPoint>: ChartPointsLayer<T> {
     }()
     
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T], locChangedFunc: (CGPoint) -> (), lineColor: UIColor = UIColor.blackColor(), lineWidth: CGFloat = 1) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T], locChangedFunc: (CGPoint) -> (), lineColor: UIColor = UIColor.blackColor(), lineWidth: CGFloat = 1) {
         self.locChangedFunc = locChangedFunc
         self.lineColor = lineColor
         self.lineWidth = lineWidth

--- a/SwiftCharts/Layers/ChartPointsViewsLayer.swift
+++ b/SwiftCharts/Layers/ChartPointsViewsLayer.swift
@@ -22,7 +22,7 @@ public class ChartPointsViewsLayer<T: ChartPoint, U: UIView>: ChartPointsLayer<T
     
     private var conflictSolver: ChartViewsConflictSolver<T, U>?
     
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints:[T], viewGenerator: ChartPointViewGenerator, conflictSolver: ChartViewsConflictSolver<T, U>? = nil, displayDelay: Float = 0, delayBetweenItems: Float = 0) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints:[T], viewGenerator: ChartPointViewGenerator, conflictSolver: ChartViewsConflictSolver<T, U>? = nil, displayDelay: Float = 0, delayBetweenItems: Float = 0) {
         self.viewGenerator = viewGenerator
         self.conflictSolver = conflictSolver
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints, displayDelay: displayDelay)

--- a/SwiftCharts/Layers/ChartShowCoordsLinesLayer.swift
+++ b/SwiftCharts/Layers/ChartShowCoordsLinesLayer.swift
@@ -12,7 +12,7 @@ public class ChartShowCoordsLinesLayer<T: ChartPoint>: ChartPointsLayer<T> {
     
     private var view: UIView?
 
-    public init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, chartPoints: [T]) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, chartPoints: [T]) {
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, chartPoints: chartPoints)
     }
     

--- a/SwiftCharts/Layers/ChartStackedBarsLayer.swift
+++ b/SwiftCharts/Layers/ChartStackedBarsLayer.swift
@@ -37,8 +37,8 @@ class ChartStackedBarsViewGenerator<T: ChartStackedBarModel>: ChartBarsViewGener
     
     private typealias FrameBuilder = (barModel: ChartStackedBarModel, item: ChartStackedBarItemModel, currentTotalQuantity: Double) -> (frame: ChartPointViewBarStackedFrame, length: CGFloat)
     
-    override init(horizontal: Bool, xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, chartInnerFrame: CGRect, barWidth barWidthMaybe: CGFloat?, barSpacing barSpacingMaybe: CGFloat?) {
-        super.init(horizontal: horizontal, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: chartInnerFrame, barWidth: barWidthMaybe, barSpacing: barSpacingMaybe)
+    override init(horizontal: Bool, xAxis: ChartAxis, yAxis: ChartAxis, chartInnerFrame: CGRect, barWidth: CGFloat) {
+        super.init(horizontal: horizontal, xAxis: xAxis, yAxis: yAxis, chartInnerFrame: chartInnerFrame, barWidth: barWidth)
     }
     
     override func generateView(barModel: T, constantScreenLoc constantScreenLocMaybe: CGFloat? = nil, bgColor: UIColor? = nil, animDuration: Float) -> ChartPointViewBar {
@@ -46,8 +46,8 @@ class ChartStackedBarsViewGenerator<T: ChartStackedBarModel>: ChartBarsViewGener
         let constantScreenLoc = constantScreenLocMaybe ?? self.constantScreenLoc(barModel)
         
         let frameBuilder: FrameBuilder = {
-            switch self.direction {
-                case .LeftToRight:
+            switch self.horizontal {
+                case true:
                     return {barModel, item, currentTotalQuantity in
                         let p0 = self.xAxis.screenLocForScalar(currentTotalQuantity)
                         let p1 = self.xAxis.screenLocForScalar(currentTotalQuantity + item.quantity)
@@ -61,7 +61,7 @@ class ChartStackedBarsViewGenerator<T: ChartStackedBarModel>: ChartBarsViewGener
                                 length,
                                 self.barWidth), color: item.bgColor), length: length)
                 }
-                case .BottomToTop:
+                case false:
                     return {barModel, item, currentTotalQuantity in
                         let p0 = self.yAxis.screenLocForScalar(currentTotalQuantity)
                         let p1 = self.yAxis.screenLocForScalar(currentTotalQuantity + item.quantity)
@@ -92,28 +92,15 @@ class ChartStackedBarsViewGenerator<T: ChartStackedBarModel>: ChartBarsViewGener
 }
 
 public class ChartStackedBarsLayer: ChartCoordsSpaceLayer {
-    
     private let barModels: [ChartStackedBarModel]
     private let horizontal: Bool
-    
-    private let barWidth: CGFloat?
-    private let barSpacing: CGFloat?
-    
+    private let barWidth: CGFloat
     private let animDuration: Float
-    
-    public convenience init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, barModels: [ChartStackedBarModel], horizontal: Bool = false, barWidth: CGFloat, animDuration: Float) {
-        self.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, barModels: barModels, horizontal: horizontal, barWidth: barWidth, barSpacing: nil, animDuration: animDuration)
-    }
 
-    public convenience init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, barModels: [ChartStackedBarModel], horizontal: Bool = false, barSpacing: CGFloat, animDuration: Float) {
-        self.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame, barModels: barModels, horizontal: horizontal, barWidth: nil, barSpacing: barSpacing, animDuration: animDuration)
-    }
-    
-    private init(xAxis: ChartAxisLayer, yAxis: ChartAxisLayer, innerFrame: CGRect, barModels: [ChartStackedBarModel], horizontal: Bool = false, barWidth: CGFloat? = nil, barSpacing: CGFloat?, animDuration: Float) {
+    public init(xAxis: ChartAxis, yAxis: ChartAxis, innerFrame: CGRect, barModels: [ChartStackedBarModel], horizontal: Bool = false, barWidth: CGFloat, animDuration: Float) {
         self.barModels = barModels
         self.horizontal = horizontal
         self.barWidth = barWidth
-        self.barSpacing = barSpacing
         self.animDuration = animDuration
         
         super.init(xAxis: xAxis, yAxis: yAxis, innerFrame: innerFrame)
@@ -121,7 +108,7 @@ public class ChartStackedBarsLayer: ChartCoordsSpaceLayer {
     
     public override func chartInitialized(chart chart: Chart) {
 
-        let barsGenerator = ChartStackedBarsViewGenerator(horizontal: self.horizontal, xAxis: self.xAxis, yAxis: self.yAxis, chartInnerFrame: self.innerFrame, barWidth: self.barWidth, barSpacing: self.barSpacing)
+        let barsGenerator = ChartStackedBarsViewGenerator(horizontal: self.horizontal, xAxis: self.xAxis, yAxis: self.yAxis, chartInnerFrame: self.innerFrame, barWidth: self.barWidth)
         
         for barModel in self.barModels {
             chart.addSubview(barsGenerator.generateView(barModel, animDuration: self.animDuration))


### PR DESCRIPTION
- Axis now has only data necessary to map between model values and screen locations
- Change layers to reference only axis instead of axis layer
- Modify layers that need axis layer UI data, like axis dividers layer, which needs current location of labels to reference additionally the axis layers. This may change in the future to recalculate the positions using model data and axis instead, to avoid this dependency, depending on performance/architecture requirements.
- Simplify bar layers interfaces, remove min spacing and direction settings. Now the direction is derived from the orientation of the bars (horizontal/vertical) and axis values. This improvement was a result of removing dependencies to axis layers.
- Rename some variables for better understability, add documentation.

Additional notes:
- The axis layer is still generated first. The axis depends on it to get start/end screen locations which  depends on available space - label size, etc.
- For now the axis model range is derived from the passed axis values array.
