### PR TITLE
Implement generic label generator which delegates to closure

### DIFF
--- a/SwiftCharts.xcodeproj/project.pbxproj
+++ b/SwiftCharts.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		EB093E6B1D215143001157BD /* ChartAxisLabelsGeneratorNumber.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB093E6A1D215143001157BD /* ChartAxisLabelsGeneratorNumber.swift */; };
 		EB093E6E1D21AD09001157BD /* ChartAxisLabelsConflictSolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB093E6D1D21AD09001157BD /* ChartAxisLabelsConflictSolver.swift */; };
 		EB093E701D21AD81001157BD /* ChartAxisLabelsConflictSolverMoveUpDown.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB093E6F1D21AD81001157BD /* ChartAxisLabelsConflictSolverMoveUpDown.swift */; };
+		EB093E721D2288FB001157BD /* ChartAxisLabelsGeneratorFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB093E711D2288FB001157BD /* ChartAxisLabelsGeneratorFunc.swift */; };
 		EB4CE97F1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB4CE97E1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift */; };
 		EB9B7E6B1BB8A575001B89D4 /* StraightLinePathGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9B7E6A1BB8A575001B89D4 /* StraightLinePathGenerator.swift */; };
 		EB9C88A31D1F365D003C19D1 /* ChartAxis.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB9C88A21D1F365D003C19D1 /* ChartAxis.swift */; };
@@ -342,6 +343,7 @@
 		EB093E6A1D215143001157BD /* ChartAxisLabelsGeneratorNumber.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisLabelsGeneratorNumber.swift; sourceTree = "<group>"; };
 		EB093E6D1D21AD09001157BD /* ChartAxisLabelsConflictSolver.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisLabelsConflictSolver.swift; sourceTree = "<group>"; };
 		EB093E6F1D21AD81001157BD /* ChartAxisLabelsConflictSolverMoveUpDown.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisLabelsConflictSolverMoveUpDown.swift; sourceTree = "<group>"; };
+		EB093E711D2288FB001157BD /* ChartAxisLabelsGeneratorFunc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisLabelsGeneratorFunc.swift; sourceTree = "<group>"; };
 		EB4CE97E1B93B2C1005E4264 /* ChartAxisValueDoubleScreenLoc.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxisValueDoubleScreenLoc.swift; sourceTree = "<group>"; };
 		EB9B7E6A1BB8A575001B89D4 /* StraightLinePathGenerator.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = StraightLinePathGenerator.swift; sourceTree = "<group>"; };
 		EB9C88A21D1F365D003C19D1 /* ChartAxis.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ChartAxis.swift; sourceTree = "<group>"; };
@@ -641,6 +643,7 @@
 				EB093E661D214DEF001157BD /* ChartAxisGeneratorMultiplier.swift */,
 				EB093E681D214F9A001157BD /* ChartAxisLabelsGeneratorBasic.swift */,
 				EB093E6A1D215143001157BD /* ChartAxisLabelsGeneratorNumber.swift */,
+				EB093E711D2288FB001157BD /* ChartAxisLabelsGeneratorFunc.swift */,
 				EB093E601D21421D001157BD /* ChartAxisValuesGeneratorFixed.swift */,
 				EB093E641D2142D7001157BD /* ChartAxisLabelsGeneratorFixed.swift */,
 			);
@@ -858,6 +861,7 @@
 				06405E1D1B8AA81D00A689FF /* ChartAxisValueInt.swift in Sources */,
 				EB08E2331B93A15E0030081C /* ChartAxisValueDouble.swift in Sources */,
 				06405E291B8AA81D00A689FF /* LineChart.swift in Sources */,
+				EB093E721D2288FB001157BD /* ChartAxisLabelsGeneratorFunc.swift in Sources */,
 				06405E3D1B8AA81D00A689FF /* ChartPointsSingleViewLayer.swift in Sources */,
 				06405E431B8AA81D00A689FF /* ChartAreasView.swift in Sources */,
 				06405E3B1B8AA81D00A689FF /* ChartPointsLineTrackerLayer.swift in Sources */,

--- a/SwiftCharts/Axis/ChartAxisLabelsGeneratorFunc.swift
+++ b/SwiftCharts/Axis/ChartAxisLabelsGeneratorFunc.swift
@@ -1,0 +1,30 @@
+//
+//  ChartAxisLabelsGeneratorFunc.swift
+//  SwiftCharts
+//
+//  Created by ischuetz on 28/06/16.
+//  Copyright © 2016 ivanschuetz. All rights reserved.
+//
+
+import Foundation
+
+/// Label generator that delegates to a closure, for greater flexibility
+public class ChartAxisLabelsGeneratorFunc: ChartAxisLabelsGenerator {
+
+    let f: Double -> [ChartAxisLabel]
+
+    /// Convenience initializer for function which maps scalar to a single label
+    public convenience init(f: Double -> ChartAxisLabel) {
+        self.init(f: {scalar in
+            return [f(scalar)]
+        })
+    }
+    
+    public init(f: Double -> [ChartAxisLabel]) {
+        self.f = f
+    }
+    
+    public func generate(scalar: Double) -> [ChartAxisLabel] {
+        return f(scalar)
+    }
+}


### PR DESCRIPTION
This makes possible to create new label generators without having to subclass `ChartAxisLabelsGenerator`.

Usage example:

``` swift
let labelGenerator = ChartAxisLabelsGeneratorFunc {scalar in
    return ChartAxisLabel(text: "!!\(scalar)!!", settings: newSettings)
}
let yModel = ChartAxisModel(..., labelGenerator: labelGenerator)

```
